### PR TITLE
adapted for publishing on bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "hydrolysis",
-  "private": true,
+  "main": "hydrolysis.js",
   "ignore": [
     "lib/",
     "examples/",


### PR DESCRIPTION
As polymer is only distributed over bower (and zip files) it only makes sense to enable users to install hydrolysis over bower as well. 

Changes in bower.json simply make the package public (i.e. publishable) and define hydrolysis.js as the main file (attribute required in bower.json).