### PR TITLE
Fix #158

### DIFF
--- a/lib/ast-utils/behavior-finder.js
+++ b/lib/ast-utils/behavior-finder.js
@@ -180,7 +180,8 @@ module.exports = function behaviorFinder() {
       if (isSimpleBehaviorArray(behaviorExpression(node))) {
         // TODO(ajo): Add a test to confirm the presence of `properties`.
         if (!currentBehavior.properties) currentBehavior.properties = [];
-        behaviors.push(currentBehavior);
+        if (behaviors.indexOf(currentBehavior) === -1)
+          behaviors.push(currentBehavior);
         currentBehavior = null;
       }
     },


### PR DESCRIPTION
The bug symptom:
- iron-component-page would show 2 copies of a behavior
- only happens when behavior definition was split into 2 parts, impl + array

Cause:
- hydrolysis was merging behaviors, but still reinserting the merged behavior, so we ended up with 2 copies.

Fix:
- do not insert behavior into the list if already there