### PR TITLE
Support absolute paths in FSResolver

### DIFF
--- a/lib/loader/fs-resolver.js
+++ b/lib/loader/fs-resolver.js
@@ -31,6 +31,16 @@ function getFile(filePath, deferred, secondPath) {
 }
 
 /**
+ * Returns true if `p` is an absolute path.
+ * TODO: Replace with path.isAbsolute() once node 0.10 support is no longer needed.
+ * @param  {string}  p path
+ * @return {boolean}
+ */
+function isAbsolute(p) {
+  return path.normalize(p + '/') === path.normalize(path.resolve(p) + '/');
+}
+
+/**
  * Returns true if `patha` is a sibling or aunt of `pathb`.
  * @return {boolean}
  */
@@ -90,7 +100,7 @@ FSResolver.prototype = {
       if (base) {
         local = path.relative(base, local);
       }
-      if (root) {
+      if (root && !isAbsolute(local)) {
         local = path.join(root, local);
       }
 


### PR DESCRIPTION
This patch checks if the `local` path is an absolute path, and if so, does not prefix it with the `root` path.
`polylint` for example always supplies both, causing absolute paths to fail.
Since SublimeLinter mostly uses an input stream (not gotten it to work) or an absolute path, merging this would make PolymerLabs/polylint#22 a lot easier to accomplish.