### PR TITLE
Support absolute paths in FSResolver

### DIFF
--- a/lib/loader/fs-resolver.js
+++ b/lib/loader/fs-resolver.js
@@ -13,6 +13,7 @@
 
 var fs = require('fs');
 var path = require('path');
+var pathIsAbsolute = require('path-is-absolute');
 var url = require('url');
 
 function getFile(filePath, deferred, secondPath) {
@@ -90,7 +91,7 @@ FSResolver.prototype = {
       if (base) {
         local = path.relative(base, local);
       }
-      if (root) {
+      if (root && !pathIsAbsolute(local)) {
         local = path.join(root, local);
       }
 

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "dom5": "^1.1.0",
     "es6-promise": "^2.1.0",
     "espree": "^2.0.1",
-    "estraverse": "^3.1.0"
+    "estraverse": "^3.1.0",
+    "path-is-absolute": "^1.0.0"
   }
 }


### PR DESCRIPTION
Since #168 was merged, I can't amend that commit anymore.
This is an alternative implementation with the https://github.com/sindresorhus/path-is-absolute ponyfill/polyfill.

This support is needed for PolymerLabs/polylint#22