### PR TITLE
Traverse unknown JS AST nodes, rather than error.

### DIFF
--- a/lib/ast-utils/js-parse.js
+++ b/lib/ast-utils/js-parse.js
@@ -40,7 +40,8 @@ function traverse(visitorRegistries) {
     leave: function(node, parent) {
       visitor = 'leave' + node.type;
       return applyVisitors(visitor, node, parent);
-    }
+    },
+    fallback: 'iteration',
   };
 }
 

--- a/test/js-parser.html
+++ b/test/js-parser.html
@@ -10,6 +10,23 @@
     var hyd = require('hydrolysis');
     var mod = document.querySelector("#modules");
     var ele = document.querySelector("#elements");
+
+    suite('ES6 support', function() {
+
+      test('parses classes', function(done) {
+        var loader = new hyd.Loader();
+        loader.addResolver(new hyd.XHRResolver());
+        loader.request("static/es6-support.js")
+          .then(function(content) {
+            var parsed = hyd._jsParse(content);
+            done();
+          }).catch(function(e) {
+            done(e);
+          });
+      });
+
+    });
+
     suite('parser throws errors', function() {
       /*
        * Two js documents, one with an error and one with a module

--- a/test/static/es6-support.js
+++ b/test/static/es6-support.js
@@ -1,0 +1,5 @@
+class A {
+  constructor() {
+    super();
+  }
+}


### PR DESCRIPTION
Fixes #141 and possibly a lot more handling of ES6 features. Turns out that even enabling new features on espree isn't helpful because estraverse isn't aware of all the new AST node types. This change adds `fallback: 'iteration'` which tells estraverse to just iterate on the children of the unknown node.