### PR TITLE
Properly manipulate script tags with external scripts

### DIFF
--- a/custom_typings/dom5.d.ts
+++ b/custom_typings/dom5.d.ts
@@ -37,6 +37,7 @@ declare module 'dom5' {
   export function removeAttribute(node: Node, attrName: string): string;
   export function getTextContent(node: Node): string;
   export function setTextContent(node: Node, string: string): void;
+  export function append(parent: Node, newNode: Node): void;
   export function remove(willBeRemoved: Node): void;
   export function replace(current: Node, replacement: Node): void;
 
@@ -53,6 +54,7 @@ declare module 'dom5' {
 
   interface Constructors {
     element(tagName: string): Node;
+    text(content: string): Node;
   }
   export var constructors: Constructors;
 }

--- a/src/analyzer.ts
+++ b/src/analyzer.ts
@@ -439,11 +439,10 @@ export class Analyzer {
       var resolvedSrc = url.resolve(href, src);
       return this.loader.request(resolvedSrc).then((content) => {
         this._content[resolvedSrc] = content;
-        var resolvedScript = Object.create(script);
-        resolvedScript.childNodes = [{value: content}];
-        resolvedScript.attrs = resolvedScript.attrs.slice();
-        dom5.removeAttribute(resolvedScript, 'src');
-        return this._processScript(resolvedScript, resolvedSrc);
+        var scriptText = dom5.constructors.text(content);
+        dom5.append(script, scriptText);
+        dom5.removeAttribute(script, 'src');
+        return this._processScript(script, resolvedSrc);
       }).catch(function(err) {throw err;});
     } else {
       return Promise.resolve(EMPTY_METADATA);


### PR DESCRIPTION
Previous handling of external script files breaks the DOM
structure and creates invalid text nodes according to dom5.

This manipulates existing script element to maintain DOM
structure and creates a text node with dom5 method.

Fixes Polymer/hydrolysis#185