### PR TITLE
make es5 and es6 classes play nicely together.

### DIFF
--- a/custom_typings/espree.d.ts
+++ b/custom_typings/espree.d.ts
@@ -4,7 +4,8 @@ declare module 'espree' {
     attachComment: boolean;
     comment: boolean;
     loc: boolean;
-    ecmaFeatures: {
+    ecmaVersion?: number;
+    ecmaFeatures?: {
       arrowFunctions: boolean;
       blockBindings: boolean;
       destructuring: boolean;

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "doctrine": "^0.7.0",
     "dom5": "^1.1.0",
     "escodegen": "^1.7.0",
-    "espree": "^2.0.1",
+    "espree": "^3.1.3",
     "estraverse": "^3.1.0",
     "path-is-absolute": "^1.0.0"
   }

--- a/src/ast-utils/element-finder.ts
+++ b/src/ast-utils/element-finder.ts
@@ -40,8 +40,8 @@ export function elementFinder() {
       this.classDetected = true;
       element = {
         type: 'element',
-        desc: esutil.getAttachedComment(parent),
-        events: esutil.getEventComments(parent).map(function(event) {
+        desc: esutil.getAttachedComment(node),
+        events: esutil.getEventComments(node).map(function(event) {
           return { desc: event };
         }),
         properties: [],
@@ -58,9 +58,13 @@ export function elementFinder() {
         element = null;
         propertyHandlers = null;
       }
+      this.classDetected = false;
     },
 
     enterAssignmentExpression: function enterAssignmentExpression(node, parent) {
+      if (!element) {
+        return;
+      }
       const left = <estree.MemberExpression>node.left;
       if (left && left.object && left.object.type !== 'ThisExpression') {
         return;
@@ -75,6 +79,9 @@ export function elementFinder() {
     },
 
     enterMethodDefinition: function enterMethodDefinition(node, parent) {
+      if (!element) {
+        return;
+      }
       var prop = <estree.Property>{
         key: node.key,
         value: node.value,

--- a/src/ast-utils/js-parse.ts
+++ b/src/ast-utils/js-parse.ts
@@ -47,29 +47,7 @@ export function jsParse(jsString:string) {
     attachComment: true,
     comment: true,
     loc: true,
-    ecmaFeatures: {
-      arrowFunctions: true,
-      blockBindings: true,
-      destructuring: true,
-      regexYFlag: true,
-      regexUFlag: true,
-      templateStrings: true,
-      binaryLiterals: true,
-      unicodeCodePointEscapes: true,
-      defaultParams: true,
-      restParams: true,
-      forOf: true,
-      objectLiteralComputedProperties: true,
-      objectLiteralShorthandMethods: true,
-      objectLiteralShorthandProperties: true,
-      objectLiteralDuplicateProperties: true,
-      generators: true,
-      spread: true,
-      classes: true,
-      modules: true,
-      jsx: true,
-      globalReturn: true,
-    }
+    ecmaVersion: 6
   });
 
   var featureInfo = featureFinder();

--- a/test/js-parser.html
+++ b/test/js-parser.html
@@ -19,7 +19,7 @@
         loader.request("static/es6-support.js")
           .then(function(content) {
             var parsed = hyd._jsParse(content);
-            assert.equal(parsed.elements.length, 1);
+            assert.equal(parsed.elements.length, 2);
             assert.equal(parsed.elements[0].behaviors.length, 2);
             assert.equal(parsed.elements[0].behaviors[0], 'Behavior1');
             assert.equal(parsed.elements[0].behaviors[1], 'Behavior2');

--- a/test/static/es6-support.js
+++ b/test/static/es6-support.js
@@ -1,3 +1,4 @@
+'use strict';
 class A {
   constructor() {
     super();
@@ -46,3 +47,82 @@ class A {
     this.data = 'Hello World';
   }
 }
+
+/**
+ * I am a description of test-element.
+ *
+ * @hero /path/to/hero.png
+ * @demo
+ * @demo /demo/index.php I am a php demo
+ * @demo /demo/no_desc.html
+ */
+Polymer({
+
+  is: 'test-element',
+
+  /**
+   * Fired when properties on `data` are added, removed, or modified.
+   *
+   * @event data-change
+   */
+
+  /**
+   * Fired when an error occurs on an interaction with Firebase.  The
+   * `details.error` property contains the `Error` object provided by
+   * the Firebase API.
+   *
+   * @event error
+   */
+
+  properties: {
+    /**
+     * I am a string!
+     */
+    stringProp: String,
+    /**
+     * I am a number!
+     */
+    numProp: Number,
+    /**
+     * I am an object!
+     */
+    objectProp: Object,
+    /**
+     * I am an object with explicit type!
+     * @type HTMLElement
+     */
+    elementProp: Object,
+    /**
+     * I am an object with notify=true!
+     */
+    objectNotify: {
+      type: Object,
+      notify: true
+    },
+    /**
+     * I am an object with notify=!0
+     */
+    objectNotifyUnary: {
+      type: Object,
+      notify: !0
+    },
+    /**
+     * I am a boolean property!
+     */
+    boolProp: Boolean
+  },
+
+  bind: {
+    numProp: 'numChanged',
+    elementProp: 'elemChanged'
+  },
+
+  numChanged: function() {
+
+  },
+
+  elemChanged: function() {
+
+  }
+
+});


### PR DESCRIPTION
Add some escape routes for walking the tree without an element.
ES6 classes now play well with ES5 elements.

ES6 support caused any es5-defined elements to throw during parsing.