### PR TITLE
Fix our exported type definitions.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,12 +4,5 @@ bower_components
 .idea
 npm-debug.log
 
-typings/
-
-# lib is where typescript + babel output goes
+# lib is where the compiled output goes
 lib/
-# typescript's ES6 output goes in src/*.js before babel transforms it and
-# moves it to lib
-src/*.js
-src/ast-utils/*.js
-src/loader/*.js

--- a/.npmignore
+++ b/.npmignore
@@ -2,8 +2,7 @@ node_modules
 bower_components
 .DS_Store
 .idea
+npm-debug.log
 
-typings/
-
-# Our typescript source and the ES6 it emits
+# The raw typescript source
 src/

--- a/custom_typings/main.d.ts
+++ b/custom_typings/main.d.ts
@@ -1,1 +1,7 @@
+/// <reference path="./doctrine.d.ts" />
+/// <reference path="./dom5.d.ts" />
+/// <reference path="./escodegen.d.ts" />
+/// <reference path="./espree.d.ts" />
+/// <reference path="./estraverse.d.ts" />
 /// <reference path="./estree.d.ts" />
+/// <reference path="./shady-css-parser.d.ts" />

--- a/src/ast/event-descriptor.ts
+++ b/src/ast/event-descriptor.ts
@@ -1,5 +1,5 @@
-import {Descriptor} from './descriptor.ts';
-import {BehaviorOrName} from './behavior-descriptor.ts';
+import {Descriptor} from './descriptor';
+import {BehaviorOrName} from './behavior-descriptor';
 
 export interface EventDescriptor extends Descriptor {
   name?: string;

--- a/src/ast/feature-descriptor.ts
+++ b/src/ast/feature-descriptor.ts
@@ -1,4 +1,4 @@
-import {ElementDescriptor} from './element-descriptor.ts';
+import {ElementDescriptor} from './element-descriptor';
 
 /**
  * The metadata for a Polymer feature.

--- a/src/ast/function-descriptor.ts
+++ b/src/ast/function-descriptor.ts
@@ -1,4 +1,4 @@
-import {PropertyDescriptor} from './property-descriptor.ts';
+import {PropertyDescriptor} from './property-descriptor';
 
 export interface FunctionDescriptor extends PropertyDescriptor {
   function: boolean; // true

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,8 @@
  * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
  */
 
+/// <reference path="../custom_typings/main.d.ts" />
+
 'use strict';
 
 /**

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,7 @@
         "declaration": true
     },
     "include": [
-        "custom_typings/**.d.ts",
+        "custom_typings/main.d.ts",
         "src/**/*.ts",
         "src/analyzer.ts"
     ]


### PR DESCRIPTION
With these changes, hydrolysis works properly in a downstream typescript
project when `npm link`ed in.