### PR TITLE
Clang format all the things

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,6 @@
+BasedOnStyle: Google
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: None
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,5 @@
 // Place your settings in this file to overwrite default and user settings.
 {
-    "clang-format.fallbackStyle": "google",
+    "clang-format.style": "file",
     "clang-format.formatOnSave": true
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,8 @@
 // Place your settings in this file to overwrite default and user settings.
 {
-    "clang-format.style": "file",
-    "clang-format.formatOnSave": true
+  "clang-format.style": "file",
+  "clang-format.formatOnSave": true
+  "files.exclude": {
+    "lib/**": true
+  }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,5 @@
 // Place your settings in this file to overwrite default and user settings.
 {
     "clang-format.fallbackStyle": "google",
-    "clang-format.formatOnSave": true,
+    "clang-format.formatOnSave": true
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+// Place your settings in this file to overwrite default and user settings.
+{
+    "clang-format.fallbackStyle": "google",
+    "clang-format.formatOnSave": true,
+}

--- a/custom_typings/doctrine.d.ts
+++ b/custom_typings/doctrine.d.ts
@@ -6,7 +6,8 @@ declare module 'doctrine' {
     type: Type;
   }
   class Type {}
-  export var type: {stringify(type: Type): string;} interface Options {
+  export var type: {stringify(type: Type): string;};
+  interface Options {
     unwrap: boolean;
     lineNumber: boolean;
     preserveWhitespace: boolean;

--- a/custom_typings/doctrine.d.ts
+++ b/custom_typings/doctrine.d.ts
@@ -6,10 +6,7 @@ declare module 'doctrine' {
     type: Type;
   }
   class Type {}
-  export var type: {
-    stringify(type: Type):string;
-  }
-  interface Options {
+  export var type: {stringify(type: Type): string;} interface Options {
     unwrap: boolean;
     lineNumber: boolean;
     preserveWhitespace: boolean;
@@ -18,5 +15,5 @@ declare module 'doctrine' {
     description: string;
     tags: Tag[];
   }
-  export function parse(content:string, options:Options):Annotation;
+  export function parse(content: string, options: Options): Annotation;
 }

--- a/custom_typings/dom5.d.ts
+++ b/custom_typings/dom5.d.ts
@@ -12,18 +12,18 @@ declare module 'dom5' {
     locationInfo: boolean;
   }
 
-  export function parse(text: string, opts?: ParseOptions):Node;
-  export function parseFragment(text: string, opts?: ParseOptions):Node;
+  export function parse(text: string, opts?: ParseOptions): Node;
+  export function parseFragment(text: string, opts?: ParseOptions): Node;
 
   export function serialize(node: Node): string;
 
-  export type Predicate = (n:Node) => boolean;
-  export function query(root: Node, predicate: Predicate):Node;
-  export function queryAll(root: Node, predicate: Predicate):Node[];
-  export function nodeWalk(node: Node, predicate: Predicate):Node;
-  export function nodeWalkAll(node: Node, predicate: Predicate):Node[];
-  export function nodeWalkAllPrior(node: Node, predicate: Predicate):Node[];
-  export function treeMap(node: Node, walker:(node: Node)=>void):void;
+  export type Predicate = (n: Node) => boolean;
+  export function query(root: Node, predicate: Predicate): Node;
+  export function queryAll(root: Node, predicate: Predicate): Node[];
+  export function nodeWalk(node: Node, predicate: Predicate): Node;
+  export function nodeWalkAll(node: Node, predicate: Predicate): Node[];
+  export function nodeWalkAllPrior(node: Node, predicate: Predicate): Node[];
+  export function treeMap(node: Node, walker: (node: Node) => void): void;
   export function getAttribute(node: Node, attrName: string): string;
   export function removeAttribute(node: Node, attrName: string): string;
   export function getTextContent(node: Node): string;
@@ -35,12 +35,12 @@ declare module 'dom5' {
 
   export var isCommentNode: Predicate;
   interface PredicateCombinators {
-    hasTagName(name: string):Predicate;
+    hasTagName(name: string): Predicate;
     hasAttr(name: string): Predicate;
     hasAttrValue(name: string, value: string): Predicate;
-    NOT(pred: Predicate):Predicate;
-    AND(...preds: Predicate[]):Predicate;
-    OR(...preds: Predicate[]):Predicate;
+    NOT(pred: Predicate): Predicate;
+    AND(...preds: Predicate[]): Predicate;
+    OR(...preds: Predicate[]): Predicate;
   }
   export var predicates: PredicateCombinators;
 

--- a/custom_typings/escodegen.d.ts
+++ b/custom_typings/escodegen.d.ts
@@ -3,8 +3,11 @@ declare module 'escodegen' {
   interface GenerateOpts {
     comment?: boolean;
     format?: {
-      indent?:
-          {style?: string; base?: number; adjustMultilineComment: boolean;}
+      indent?: {
+        style?: string;  //
+        base?: number;
+        adjustMultilineComment: boolean;
+      }
     }
   }
   export function generate(ast: Node, opts?: GenerateOpts): string;

--- a/custom_typings/escodegen.d.ts
+++ b/custom_typings/escodegen.d.ts
@@ -3,13 +3,9 @@ declare module 'escodegen' {
   interface GenerateOpts {
     comment?: boolean;
     format?: {
-      indent?: {
-        style?: string;
-        base?: number;
-        adjustMultilineComment: boolean;
-      }
+      indent?:
+          {style?: string; base?: number; adjustMultilineComment: boolean;}
     }
   }
-  export function generate(ast:Node, opts?: GenerateOpts):string;
-
+  export function generate(ast: Node, opts?: GenerateOpts): string;
 }

--- a/custom_typings/espree.d.ts
+++ b/custom_typings/espree.d.ts
@@ -6,7 +6,7 @@ declare module 'espree' {
     loc: boolean;
     ecmaVersion?: number;
     ecmaFeatures?: {
-      arrowFunctions: boolean;
+      arrowFunctions: boolean;  //
       blockBindings: boolean;
       destructuring: boolean;
       regexYFlag: boolean;
@@ -29,5 +29,5 @@ declare module 'espree' {
       globalReturn: boolean;
     }
   }
-  export function parse(text: string, opts?: ParseOpts):estree.Program;
+  export function parse(text: string, opts?: ParseOpts): estree.Program;
 }

--- a/custom_typings/estraverse.d.ts
+++ b/custom_typings/estraverse.d.ts
@@ -1,19 +1,17 @@
 declare module 'estraverse' {
   import {Node} from 'estree';
   interface Callbacks {
-    enter?: (node:Node, parent:Node)=>any;
-    leave?: (node:Node, parent:Node)=>any;
+    enter?: (node: Node, parent: Node) => any;
+    leave?: (node: Node, parent: Node) => any;
 
     fallback?: string;
 
     // Methods provided for you, don't override.
-    break?: ()=>void;
-    remove?: ()=>void;
-    skip?: ()=>void;
+    break?: () => void;
+    remove?: () => void;
+    skip?: () => void;
     keys?: {};
   }
-  export enum VisitorOption {
-      Skip, Break, Remove
-  }
-  export function traverse(n: Node, callbacks:Callbacks):void;
+  export enum VisitorOption {Skip, Break, Remove}
+  export function traverse(n: Node, callbacks: Callbacks): void;
 }

--- a/custom_typings/estree.d.ts
+++ b/custom_typings/estree.d.ts
@@ -1,4 +1,5 @@
-// TODO(rictic): Upstream/merge with https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/estree/estree.d.ts
+// TODO(rictic): Upstream/merge with
+// https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/estree/estree.d.ts
 
 declare module 'estree' {
   interface BaseNode {
@@ -9,15 +10,12 @@ declare module 'estree' {
     trailingComments?: Comment[];
     loc?: SourceLocation;
   }
-  export type Node =
-      Identifier | Literal | Program | Function | SwitchCase | CatchClause |
-      VariableDeclarator | Statement | Expression | Property |
+  export type Node = Identifier | Literal | Program | Function | SwitchCase |
+      CatchClause | VariableDeclarator | Statement | Expression | Property |
       AssignmentProperty | Super | TemplateElement | SpreadElement | Pattern |
       ClassBody | ClassDeclaration | ClassExpression | MethodDefinition |
       ModuleDeclaration | ModuleSpecifier;
-  export interface Comment {
-    value: string;
-  }
+  export interface Comment { value: string; }
   export interface SourceLocation {
     source: string;
     start: Position;
@@ -40,15 +38,12 @@ declare module 'estree' {
     raw: string;
   }
   export interface RegExpLiteral extends Literal {
-    regex: {
-      pattern: string;
-      flags: string;
-    };
+    regex: {pattern: string; flags: string;};
   }
   export interface Program extends BaseNode {
     type: 'Program';
-    sourceType: string; // "script" or "module"
-    body: Statement[]|ModuleDeclaration[];
+    sourceType: string;  // "script" or "module"
+    body: Statement[] | ModuleDeclaration[];
   }
   export type Function = FunctionDeclaration | FunctionExpression;
   interface BaseFunction extends BaseNode {
@@ -57,13 +52,13 @@ declare module 'estree' {
     body: BlockStatement;
     generator?: boolean;
   }
-  export type Statement =
-      ExpressionStatement | BlockStatement | EmptyStatement |
-      DebuggerStatement | WithStatement | ReturnStatement | LabeledStatement |
-      BreakStatement | ContinueStatement | IfStatement | SwitchStatement |
-      ThrowStatement | TryStatement | WhileStatement | DoWhileStatement |
-      ForStatement | ForInStatement | ForOfStatement | Declaration;
-  interface BaseStatement extends BaseNode { }
+  export type Statement = ExpressionStatement | BlockStatement |
+      EmptyStatement | DebuggerStatement | WithStatement | ReturnStatement |
+      LabeledStatement | BreakStatement | ContinueStatement | IfStatement |
+      SwitchStatement | ThrowStatement | TryStatement | WhileStatement |
+      DoWhileStatement | ForStatement | ForInStatement | ForOfStatement |
+      Declaration;
+  interface BaseStatement extends BaseNode {}
   export interface ExpressionStatement extends BaseStatement {
     type: "ExpressionStatement";
     expression: Expression;
@@ -153,7 +148,7 @@ declare module 'estree' {
     body: Statement;
   }
   interface ForXStatement extends BaseStatement {
-    left: VariableDeclaration |  Expression;
+    left: VariableDeclaration | Expression;
     right: Expression;
     body: Statement;
   }
@@ -166,7 +161,7 @@ declare module 'estree' {
 
   export type Declaration =
       FunctionDeclaration | VariableDeclaration | ClassDeclaration;
-  interface BaseDeclaration extends BaseStatement { }
+  interface BaseDeclaration extends BaseStatement {}
   export interface FunctionDeclaration extends BaseFunction, BaseDeclaration {
     type: "FunctionDeclaration";
     id: Identifier;
@@ -182,20 +177,20 @@ declare module 'estree' {
     init?: Expression;
   }
 
-  type Expression =
-      ThisExpression | ArrayExpression | ObjectExpression | FunctionExpression |
-      ArrowFunctionExpression | YieldExpression | Literal | UnaryExpression |
-      UpdateExpression | BinaryExpression | AssignmentExpression |
-      LogicalExpression | MemberExpression | ConditionalExpression |
-      CallExpression | NewExpression | SequenceExpression | TemplateLiteral |
-      TaggedTemplateExpression | ClassExpression | MetaProperty | Identifier;
-  export interface BaseExpression extends BaseNode { }
+  type Expression = ThisExpression | ArrayExpression | ObjectExpression |
+      FunctionExpression | ArrowFunctionExpression | YieldExpression | Literal |
+      UnaryExpression | UpdateExpression | BinaryExpression |
+      AssignmentExpression | LogicalExpression | MemberExpression |
+      ConditionalExpression | CallExpression | NewExpression |
+      SequenceExpression | TemplateLiteral | TaggedTemplateExpression |
+      ClassExpression | MetaProperty | Identifier;
+  export interface BaseExpression extends BaseNode {}
   export interface ThisExpression extends BaseExpression {
     type: "ThisExpression";
   }
   export interface ArrayExpression extends BaseExpression {
     type: "ArrayExpression";
-    elements: (Expression|SpreadElement)[];
+    elements: (Expression | SpreadElement)[];
   }
 
   export interface ObjectExpression extends BaseExpression {
@@ -211,9 +206,7 @@ declare module 'estree' {
     shorthand: boolean;
     computed: boolean;
   }
-  export interface Property extends BaseProperty {
-    value: Expression;
-  }
+  export interface Property extends BaseProperty { value: Expression; }
   export interface FunctionExpression extends BaseFunction, BaseExpression {
     type: "FunctionExpression";
   }
@@ -229,9 +222,7 @@ declare module 'estree' {
     argument?: Expression;
     delegate: boolean;
   }
-  export interface Super extends BaseNode {
-    type: "Super";
-  }
+  export interface Super extends BaseNode { type: "Super"; }
 
 
   export interface UnaryExpression extends BaseExpression {
@@ -256,19 +247,17 @@ declare module 'estree' {
     left: Expression;
     right: Expression;
   }
-  export type BinaryOperator =
-      "==" | "!=" | "===" | "!==" | "<" | "<=" | ">" | ">=" | "<<" |
-      ">>" | ">>>" | "+" | "-" | "*" | "/" | "%" | "|" | "^" | "&" | "in" |
-      "instanceof";
+  export type BinaryOperator = "==" | "!=" | "===" | "!==" | "<" | "<=" | ">" |
+      ">=" | "<<" | ">>" | ">>>" | "+" | "-" | "*" | "/" | "%" | "|" | "^" |
+      "&" | "in" | "instanceof";
   export interface AssignmentExpression extends BaseExpression {
     type: "AssignmentExpression";
     operator: AssignmentOperator;
     left: Pattern | MemberExpression;
     right: Expression;
   }
-  export type AssignmentOperator =
-      "=" | "+=" | "-=" | "*=" | "/=" | "%=" | "<<=" | ">>=" | ">>>=" |
-      "|=" | "^=" | "&=";
+  export type AssignmentOperator = "=" | "+=" | "-=" | "*=" | "/=" | "%=" |
+      "<<=" | ">>=" | ">>>=" | "|=" | "^=" | "&=";
   export interface LogicalExpression extends BaseExpression {
     type: "LogicalExpression";
     operator: LogicalOperator;
@@ -291,7 +280,7 @@ declare module 'estree' {
   }
   interface BaseCallExpression extends BaseExpression {
     callee: Expression | Super;
-    arguments: (Expression|SpreadElement)[];
+    arguments: (Expression | SpreadElement)[];
   }
   export interface CallExpression extends BaseCallExpression {
     type: "CallExpression";
@@ -317,10 +306,7 @@ declare module 'estree' {
   export interface TemplateElement extends BaseNode {
     type: "TemplateElement";
     tail: boolean;
-    value: {
-        cooked: string;
-        raw: string;
-    };
+    value: {cooked: string; raw: string;};
   }
 
   export interface SpreadElement extends BaseNode {
@@ -328,10 +314,9 @@ declare module 'estree' {
     argument: Expression;
   }
 
-  type Pattern =
-      ObjectPattern | ArrayPattern | RestElement | AssignmentPattern |
-      MemberExpression;
-  export interface BasePattern extends BaseNode { }
+  type Pattern = ObjectPattern | ArrayPattern | RestElement |
+      AssignmentPattern | MemberExpression;
+  export interface BasePattern extends BaseNode {}
   export interface AssignmentProperty extends BaseProperty {
     value: Pattern;
     kind: "init";
@@ -388,20 +373,19 @@ declare module 'estree' {
     property: Identifier;
   }
 
-  export type ModuleDeclaration =
-      ImportDeclaration | ExportNamedDeclaration | ExportDefaultDeclaration |
-      ExportAllDeclaration;
-  interface BaseModuleDeclaration extends BaseNode { }
-  export type ModuleSpecifier =
-      ImportSpecifier | ImportDefaultSpecifier | ImportNamespaceSpecifier |
-      ExportSpecifier;
+  export type ModuleDeclaration = ImportDeclaration | ExportNamedDeclaration |
+      ExportDefaultDeclaration | ExportAllDeclaration;
+  interface BaseModuleDeclaration extends BaseNode {}
+  export type ModuleSpecifier = ImportSpecifier | ImportDefaultSpecifier |
+      ImportNamespaceSpecifier | ExportSpecifier;
   interface BaseModuleSpecifier extends BaseNode {
     local: Identifier;
   }
 
   export interface ImportDeclaration extends BaseModuleDeclaration {
     type: "ImportDeclaration";
-    specifiers: (ImportSpecifier|ImportDefaultSpecifier|ImportNamespaceSpecifier)[];
+    specifiers:
+        (ImportSpecifier | ImportDefaultSpecifier | ImportNamespaceSpecifier)[];
     source: Literal;
   }
   export interface ImportSpecifier extends BaseModuleSpecifier {

--- a/custom_typings/shady-css-parser.d.ts
+++ b/custom_typings/shady-css-parser.d.ts
@@ -1,10 +1,6 @@
 declare module 'shady-css-parser' {
-  export class Parser {
-    parse(cssText: string): Node;
-  }
-  export interface Node {
-    type: string;
-  }
+  export class Parser { parse(cssText: string): Node; }
+  export interface Node { type: string; }
   export class NodeVisitor {
     path: Node[];
     visit(node: Node): any;

--- a/package.json
+++ b/package.json
@@ -28,10 +28,11 @@
     "apidocs": "node_modules/jsdoc-to-markdown/bin/cli.js {index.js,lib/{analyzer,loader/*}.js} > API.md",
     "lint": "gulp lint",
     "test": "npm run clean && npm run build && npm run lint && mocha",
-    "reformat": "find src test | grep '\\.js$\\|\\.ts$' | xargs clang-format --style=file -i"
+    "format": "find src test | grep '\\.js$\\|\\.ts$' | xargs clang-format --style=file -i"
   },
   "devDependencies": {
     "chai": "^2.2.0",
+    "clang-format": "^1.0.42",
     "depcheck": "^0.6.3",
     "fs-extra": "^0.30.0",
     "gulp": "^3.9.1",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "build:watch": "watch 'npm run build' ./src",
     "apidocs": "node_modules/jsdoc-to-markdown/bin/cli.js {index.js,lib/{analyzer,loader/*}.js} > API.md",
     "lint": "gulp lint",
-    "test": "npm run clean && npm run build && npm run lint && mocha"
+    "test": "npm run clean && npm run build && npm run lint && mocha",
+    "reformat": "find src test | grep '\\.js$\\|\\.ts$' | xargs clang-format --style=file -i"
   },
   "devDependencies": {
     "chai": "^2.2.0",

--- a/src/analyzer.ts
+++ b/src/analyzer.ts
@@ -27,11 +27,7 @@ import {ElementFinder} from './javascript/javascript-element-finder';
 import {JavaScriptParser} from './javascript/javascript-parser';
 import {Document} from './parser/document';
 import {Parser} from './parser/parser';
-import {
-  Descriptor,
-  DocumentDescriptor,
-  ImportDescriptor,
-} from './ast/ast';
+import {Descriptor, DocumentDescriptor, ImportDescriptor} from './ast/ast';
 import {UrlLoader} from './url-loader/url-loader';
 
 export interface Options {

--- a/src/analyzer.ts
+++ b/src/analyzer.ts
@@ -1,11 +1,15 @@
 /**
  * @license
  * Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
- * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
- * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
- * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
  * Code distributed by Google as part of the polymer project is also
- * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
  */
 
 import * as path from 'path';
@@ -45,20 +49,22 @@ export interface Options {
  * finders which do the actual work of understanding different file types.
  */
 export class Analyzer {
-
   private _parsers: Map<string, Parser<any>> = new Map<string, Parser<any>>([
-      ['html', new HtmlParser(this)],
-      ['js', new JavaScriptParser(this)],
-      ['css', new CssParser(this)],
-    ]);
+    ['html', new HtmlParser(this)],
+    ['js', new JavaScriptParser(this)],
+    ['css', new CssParser(this)],
+  ]);
 
   private _entityFinders = new Map<string, EntityFinder<any, any, any>[]>([
-        ['html', [
-          new HtmlImportFinder(),
-          new HtmlScriptFinder(this),
-          new HtmlStyleFinder(this)]],
-        ['js', [new ElementFinder(this)]],
-    ]);
+    [
+      'html',
+      [
+        new HtmlImportFinder(), new HtmlScriptFinder(this),
+        new HtmlStyleFinder(this)
+      ]
+    ],
+    ['js', [new ElementFinder(this)]],
+  ]);
 
   private _loader: UrlLoader;
   private _documents = new Map<string, Promise<Document<any, any>>>();
@@ -81,7 +87,7 @@ export class Analyzer {
     if (this._documentDescriptors.has(url)) {
       return this._documentDescriptors.get(url);
     }
-    let promise = (async () => {
+    let promise = (async() => {
       // Make sure we wait and return a Promise before doing any work, so that
       // the Promise can be cached.
       await Promise.resolve();
@@ -95,9 +101,8 @@ export class Analyzer {
   /**
    * Parses and analyzes a document from source.
    */
-  async analyzeSource(
-        type: string, contents: string, url: string
-        ): Promise<DocumentDescriptor>  {
+  async analyzeSource(type: string, contents: string, url: string):
+      Promise<DocumentDescriptor> {
     let document = this.parse(type, contents, url);
     return this.analyzeDocument(document);
   }
@@ -105,8 +110,8 @@ export class Analyzer {
   /**
    * Analyzes a parsed Document object.
    */
-  async analyzeDocument(
-        document: Document<any, any>): Promise<DocumentDescriptor> {
+  async analyzeDocument(document: Document<any, any>):
+      Promise<DocumentDescriptor> {
     let entities = await this.getEntities(document);
 
     // TODO(justinfagnani): Load ImportDescriptors
@@ -130,7 +135,7 @@ export class Analyzer {
     // Use an immediately executed async function to create the final Promise
     // synchronously so we can store it in this._documents before any other
     // async operations to avoid any race conditions.
-    let promise = (async () => {
+    let promise = (async() => {
       // Make sure we wait and return a Promise before doing any work, so that
       // the Promise can be cached.
       await Promise.resolve();
@@ -160,5 +165,4 @@ export class Analyzer {
       return findEntities(document, finders);
     }
   }
-
 }

--- a/src/ast-utils/analyze-properties.ts
+++ b/src/ast-utils/analyze-properties.ts
@@ -1,11 +1,15 @@
 /**
  * @license
  * Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
- * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
- * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
- * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
  * Code distributed by Google as part of the polymer project is also
- * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
  */
 
 'use strict';
@@ -16,7 +20,6 @@ import * as estree from 'estree';
 import {PropertyDescriptor} from '../ast/ast';
 
 export function analyzeProperties(node: estree.Node) {
-
   const analyzedProps: PropertyDescriptor[] = [];
 
   if (node.type !== 'ObjectExpression') {
@@ -43,7 +46,7 @@ export function analyzeProperties(node: estree.Node) {
         const propertyKey = esutil.objectKeyToString(propertyArg.key);
 
         switch (propertyKey) {
-          case 'type': {
+          case 'type':
             prop.type = esutil.objectKeyToString(propertyArg.value);
             if (prop.type === undefined) {
               throw {
@@ -51,41 +54,40 @@ export function analyzeProperties(node: estree.Node) {
                 location: propertyArg.loc.start
               };
             }
-          }
-          break;
-          case 'notify': {
+            break;
+          case 'notify':
             prop.notify = astValue.expressionToValue(propertyArg.value);
-            if (prop.notify === undefined)
+            if (prop.notify === undefined) {
               prop.notify = astValue.CANT_CONVERT;
-          }
-          break;
-          case 'observer': {
+            }
+            break;
+          case 'observer':
             prop.observer = astValue.expressionToValue(propertyArg.value);
             prop.observerNode = propertyArg.value;
-            if (prop.observer === undefined)
+            if (prop.observer === undefined) {
               prop.observer = astValue.CANT_CONVERT;
-          }
-          break;
-          case 'readOnly': {
+            }
+            break;
+          case 'readOnly':
             prop.readOnly = astValue.expressionToValue(propertyArg.value);
-            if (prop.readOnly === undefined)
+            if (prop.readOnly === undefined) {
               prop.readOnly = astValue.CANT_CONVERT;
-          }
-          break;
-          case 'reflectToAttribute': {
+            }
+            break;
+          case 'reflectToAttribute':
             prop.reflectToAttribute = astValue.expressionToValue(propertyArg);
-            if (prop.reflectToAttribute === undefined)
+            if (prop.reflectToAttribute === undefined) {
               prop.reflectToAttribute = astValue.CANT_CONVERT;
-          }
-          break;
-          case 'value': {
+            }
+            break;
+          case 'value':
             prop.default = astValue.expressionToValue(propertyArg.value);
-            if (prop.default === undefined)
+            if (prop.default === undefined) {
               prop.default = astValue.CANT_CONVERT;
-          }
-          break;
+            }
+            break;
           default:
-          break;
+            break;
         }
       }
     }

--- a/src/ast-utils/ast-value.ts
+++ b/src/ast-utils/ast-value.ts
@@ -123,7 +123,7 @@ function objectExpressionToValue(obj: estree.ObjectExpression): string {
 /**
  * BinaryExpressions are of the form "literal" + "literal"
  */
-function binaryExpressionToValue(member: estree.BinaryExpression): number |
+function binaryExpressionToValue(member: estree.BinaryExpression): number|
     string {
   if (member.operator === '+') {
     // We need to cast to `any` here because, while it's usually not the right

--- a/src/ast-utils/ast-value.ts
+++ b/src/ast-utils/ast-value.ts
@@ -1,11 +1,15 @@
 /**
  * @license
  * Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
- * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
- * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
- * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
  * Code distributed by Google as part of the polymer project is also
- * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
  */
 
 'use strict';
@@ -28,8 +32,9 @@ function literalToValue(literal: estree.Literal): LiteralValue {
  */
 function unaryToValue(unary: estree.UnaryExpression): string {
   const argValue = expressionToValue(unary.argument);
-  if (argValue === undefined)
+  if (argValue === undefined) {
     return;
+  }
   return unary.operator + argValue;
 }
 
@@ -44,22 +49,23 @@ function identifierToValue(identifier: estree.Identifier): string {
 /**
  * Function is a block statement.
  */
-function functionDeclarationToValue(
-    fn: estree.FunctionDeclaration): LiteralValue {
-  if (fn.body.type === 'BlockStatement')
+function functionDeclarationToValue(fn: estree.FunctionDeclaration):
+    LiteralValue {
+  if (fn.body.type === 'BlockStatement') {
     return blockStatementToValue(fn.body);
+  }
 }
 
-function functionExpressionToValue(
-    fn: estree.FunctionExpression): LiteralValue {
-  if (fn.body.type === 'BlockStatement')
+function functionExpressionToValue(fn: estree.FunctionExpression):
+    LiteralValue {
+  if (fn.body.type === 'BlockStatement') {
     return blockStatementToValue(fn.body);
+  }
 }
 /**
  * Block statement: find last return statement, and return its value
  */
-function blockStatementToValue(
-    block: estree.BlockStatement): LiteralValue {
+function blockStatementToValue(block: estree.BlockStatement): LiteralValue {
   for (let i = block.body.length - 1; i >= 0; i--) {
     const body = block.body[i];
     if (body.type === 'ReturnStatement') {
@@ -117,13 +123,14 @@ function objectExpressionToValue(obj: estree.ObjectExpression): string {
 /**
  * BinaryExpressions are of the form "literal" + "literal"
  */
-function binaryExpressionToValue(
-    member: estree.BinaryExpression): number|string {
+function binaryExpressionToValue(member: estree.BinaryExpression): number |
+    string {
   if (member.operator === '+') {
     // We need to cast to `any` here because, while it's usually not the right
     // thing to do to use '+' on two values of a mix of types because it's
     // unpredictable, that is what the original code we're evaluating does.
-    return <any>expressionToValue(member.left) + expressionToValue(member.right);
+    return <any>expressionToValue(member.left) +
+        expressionToValue(member.right);
   }
   return;
 }
@@ -132,8 +139,8 @@ function binaryExpressionToValue(
  * MemberExpression references a variable with name
  */
 function memberExpressionToValue(member: estree.MemberExpression): string {
-  return expressionToValue(
-      member.object) + '.' + expressionToValue(member.property);
+  return expressionToValue(member.object) + '.' +
+      expressionToValue(member.property);
 }
 
 /**

--- a/src/ast-utils/behavior-finder.ts
+++ b/src/ast-utils/behavior-finder.ts
@@ -21,10 +21,7 @@ import * as analyzeProperties from './analyze-properties';
 import * as astValue from './ast-value';
 import * as estree from 'estree';
 import {Visitor} from './fluent-traverse';
-import {
-  declarationPropertyHandlers,
-  PropertyHandlers
-} from './declaration-property-handlers';
+import {declarationPropertyHandlers, PropertyHandlers} from './declaration-property-handlers';
 import {BehaviorDescriptor, BehaviorOrName, LiteralValue} from '../ast/ast';
 
 interface KeyFunc<T> {
@@ -118,7 +115,7 @@ export function behaviorFinder() {
    * checks whether an expression is a simple array containing only member
    * expressions or identifiers.
    */
-  function isSimpleBehaviorArray(expression: estree.Node | null): boolean {
+  function isSimpleBehaviorArray(expression: estree.Node|null): boolean {
     if (!expression || expression.type !== 'ArrayExpression') {
       return false;
     }

--- a/src/ast-utils/behavior-finder.ts
+++ b/src/ast-utils/behavior-finder.ts
@@ -41,7 +41,9 @@ function dedupe<T>(array: T[], keyFunc: KeyFunc<T>): T[] {
     bucket[key] = el;
   });
   const returned = <Array<T>>[];
-  Object.keys(bucket).forEach((k) => { returned.push(bucket[k]); });
+  Object.keys(bucket).forEach((k) => {
+    returned.push(bucket[k]);
+  });
   return returned;
 }
 
@@ -201,8 +203,10 @@ export function behaviorFinder() {
     // add it to behaviors right away.
     if (isSimpleBehaviorArray(behaviorExpression(node))) {
       // TODO(ajo): Add a test to confirm the presence of `properties`
-      if (!currentBehavior.observers) currentBehavior.observers = [];
-      if (!currentBehavior.properties) currentBehavior.properties = [];
+      if (!currentBehavior.observers)
+        currentBehavior.observers = [];
+      if (!currentBehavior.properties)
+        currentBehavior.properties = [];
       if (behaviors.indexOf(currentBehavior) === -1)
         behaviors.push(currentBehavior);
       currentBehavior = null;
@@ -216,7 +220,8 @@ export function behaviorFinder() {
      * Look for object declarations with @behavior in the docs.
      */
     enterVariableDeclaration: function(node, parent) {
-      if (node.declarations.length !== 1) return;  // Ambiguous.
+      if (node.declarations.length !== 1)
+        return;  // Ambiguous.
       _initBehavior(node, function() {
         return esutil.objectKeyToString(node.declarations[0].id);
       });
@@ -226,8 +231,9 @@ export function behaviorFinder() {
      * Look for object assignments with @polymerBehavior in the docs.
      */
     enterAssignmentExpression: function(node, parent) {
-      _initBehavior(
-          parent, function() { return esutil.objectKeyToString(node.left); });
+      _initBehavior(parent, function() {
+        return esutil.objectKeyToString(node.left);
+      });
     },
 
     /**
@@ -235,7 +241,8 @@ export function behaviorFinder() {
      * behavior's declaration. Seems to be a decent assumption for now.
      */
     enterObjectExpression: function(node, parent) {
-      if (!currentBehavior || currentBehavior.properties) return;
+      if (!currentBehavior || currentBehavior.properties)
+        return;
 
       currentBehavior.properties = currentBehavior.properties || [];
       currentBehavior.observers = currentBehavior.observers || [];

--- a/src/ast-utils/behavior-finder.ts
+++ b/src/ast-utils/behavior-finder.ts
@@ -1,11 +1,15 @@
 /**
  * @license
  * Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
- * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
- * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
- * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
  * Code distributed by Google as part of the polymer project is also
- * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
  */
 
 'use strict';
@@ -17,7 +21,10 @@ import * as analyzeProperties from './analyze-properties';
 import * as astValue from './ast-value';
 import * as estree from 'estree';
 import {Visitor} from './fluent-traverse';
-import {declarationPropertyHandlers, PropertyHandlers} from './declaration-property-handlers';
+import {
+  declarationPropertyHandlers,
+  PropertyHandlers
+} from './declaration-property-handlers';
 import {BehaviorDescriptor, BehaviorOrName, LiteralValue} from '../ast/ast';
 
 interface KeyFunc<T> {
@@ -34,9 +41,7 @@ function dedupe<T>(array: T[], keyFunc: KeyFunc<T>): T[] {
     bucket[key] = el;
   });
   const returned = <Array<T>>[];
-  Object.keys(bucket).forEach((k) => {
-    returned.push(bucket[k]);
-  });
+  Object.keys(bucket).forEach((k) => { returned.push(bucket[k]); });
   return returned;
 }
 
@@ -59,31 +64,35 @@ export function behaviorFinder() {
       return b.indexOf(newBehavior.is) === -1;
     };
     for (let i = 0; i < behaviors.length; i++) {
-      if (newBehavior.is !== behaviors[i].is)
+      if (newBehavior.is !== behaviors[i].is) {
         continue;
+      }
       // merge desc, longest desc wins
       if (newBehavior.desc) {
         if (behaviors[i].desc) {
           if (newBehavior.desc.length > behaviors[i].desc.length)
             behaviors[i].desc = newBehavior.desc;
-        }
-        else {
+        } else {
           behaviors[i].desc = newBehavior.desc;
         }
       }
       // merge demos
-      behaviors[i].demos = (behaviors[i].demos || []).concat(newBehavior.demos || []);
+      behaviors[i].demos =
+          (behaviors[i].demos || []).concat(newBehavior.demos || []);
       // merge events,
-      behaviors[i].events = (behaviors[i].events || []).concat(newBehavior.events || []);
+      behaviors[i].events =
+          (behaviors[i].events || []).concat(newBehavior.events || []);
       behaviors[i].events = dedupe(behaviors[i].events, (e) => e.name);
       // merge properties
-      behaviors[i].properties = (behaviors[i].properties || []).concat(newBehavior.properties || []);
+      behaviors[i].properties =
+          (behaviors[i].properties || []).concat(newBehavior.properties || []);
       // merge observers
-      behaviors[i].observers = (behaviors[i].observers || []).concat(newBehavior.observers || []);
+      behaviors[i].observers =
+          (behaviors[i].observers || []).concat(newBehavior.observers || []);
       // merge behaviors
-      behaviors[i].behaviors =
-        (behaviors[i].behaviors || []).concat(newBehavior.behaviors || [])
-        .filter(isBehaviorImpl);
+      behaviors[i].behaviors = (behaviors[i].behaviors || [])
+                                   .concat(newBehavior.behaviors || [])
+                                   .filter(isBehaviorImpl);
       return behaviors[i];
     }
     return newBehavior;
@@ -123,9 +132,11 @@ export function behaviorFinder() {
   const templatizer = 'Polymer.Templatizer';
 
   function _parseChainedBehaviors(node: estree.Node) {
-    // if current behavior is part of an array, it gets extended by other behaviors
+    // if current behavior is part of an array, it gets extended by other
+    // behaviors
     // inside the array. Ex:
-    // Polymer.IronMultiSelectableBehavior = [ {....}, Polymer.IronSelectableBehavior]
+    // Polymer.IronMultiSelectableBehavior = [ {....},
+    // Polymer.IronSelectableBehavior]
     // We add these to behaviors array
     const expression = behaviorExpression(node);
     const chained: BehaviorOrName[] = [];
@@ -136,8 +147,9 @@ export function behaviorFinder() {
           chained.push(<BehaviorOrName>astValue.expressionToValue(element));
         }
       }
-      if (chained.length > 0)
+      if (chained.length > 0) {
         currentBehavior.behaviors = chained;
+      }
     }
   }
 
@@ -155,8 +167,8 @@ export function behaviorFinder() {
     currentBehavior = {
       type: 'behavior',
       desc: comment,
-      events: esutil.getEventComments(node).map( function(event) {
-        return { desc: event};
+      events: esutil.getEventComments(node).map(function(event) {
+        return {desc: event};
       })
     };
     propertyHandlers = declarationPropertyHandlers(currentBehavior);
@@ -205,7 +217,7 @@ export function behaviorFinder() {
      */
     enterVariableDeclaration: function(node, parent) {
       if (node.declarations.length !== 1) return;  // Ambiguous.
-      _initBehavior(node, function () {
+      _initBehavior(node, function() {
         return esutil.objectKeyToString(node.declarations[0].id);
       });
     },
@@ -214,9 +226,8 @@ export function behaviorFinder() {
      * Look for object assignments with @polymerBehavior in the docs.
      */
     enterAssignmentExpression: function(node, parent) {
-      _initBehavior(parent, function () {
-        return esutil.objectKeyToString(node.left);
-      });
+      _initBehavior(
+          parent, function() { return esutil.objectKeyToString(node.left); });
     },
 
     /**
@@ -239,8 +250,7 @@ export function behaviorFinder() {
         }
         if (name in propertyHandlers) {
           propertyHandlers[name](prop.value);
-        }
-        else {
+        } else {
           currentBehavior.properties.push(esutil.toPropertyDescriptor(prop));
         }
       }

--- a/src/ast-utils/declaration-property-handlers.ts
+++ b/src/ast-utils/declaration-property-handlers.ts
@@ -1,21 +1,31 @@
 /**
  * @license
  * Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
- * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
- * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
- * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
  * Code distributed by Google as part of the polymer project is also
- * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
  */
 
 'use strict';
 
 import * as astValue from './ast-value';
-import {PropertyDescriptor, ElementDescriptor, BehaviorOrName} from '../ast/ast';
+import {
+  PropertyDescriptor,
+  ElementDescriptor,
+  BehaviorOrName
+} from '../ast/ast';
 import {analyzeProperties} from './analyze-properties';
 import * as estree from 'estree';
 
-export type PropertyHandlers = {[key: string]: (node: estree.Node) => void};
+export type PropertyHandlers = {
+  [key: string]: (node: estree.Node) => void
+};
 /**
  * Returns an object containing functions that will annotate `declaration` with
  * the polymer-specificmeaning of the value nodes for the named properties.
@@ -24,21 +34,22 @@ export type PropertyHandlers = {[key: string]: (node: estree.Node) => void};
  * @return {object.<string,function>}      An object containing property
  *                                         handlers.
  */
-export function declarationPropertyHandlers(declaration: ElementDescriptor): PropertyHandlers {
+export function declarationPropertyHandlers(declaration: ElementDescriptor):
+    PropertyHandlers {
   return {
-    is: function(node: estree.Node) {
+    is(node: estree.Node) {
       if (node.type === 'Literal') {
         declaration.is = node.value.toString();
       }
     },
-    properties: function(node: estree.Node) {
+    properties(node: estree.Node) {
       const props = analyzeProperties(node);
 
       for (let i = 0; i < props.length; i++) {
         declaration.properties.push(props[i]);
       }
     },
-    behaviors: function(node: estree.Node) {
+    behaviors(node: estree.Node) {
       if (node.type !== 'ArrayExpression') {
         return;
       }
@@ -50,7 +61,7 @@ export function declarationPropertyHandlers(declaration: ElementDescriptor): Pro
         declaration.behaviors.push(<BehaviorOrName>v);
       }
     },
-    observers: function(node: estree.Node) {
+    observers(node: estree.Node) {
       if (node.type !== 'ArrayExpression') {
         return;
       }
@@ -59,10 +70,7 @@ export function declarationPropertyHandlers(declaration: ElementDescriptor): Pro
         if (v === undefined) {
           v = astValue.CANT_CONVERT;
         }
-        declaration.observers.push({
-          javascriptNode: element,
-          expression: v
-        });
+        declaration.observers.push({javascriptNode: element, expression: v});
       }
     }
   };

--- a/src/ast-utils/declaration-property-handlers.ts
+++ b/src/ast-utils/declaration-property-handlers.ts
@@ -15,11 +15,7 @@
 'use strict';
 
 import * as astValue from './ast-value';
-import {
-  PropertyDescriptor,
-  ElementDescriptor,
-  BehaviorOrName
-} from '../ast/ast';
+import {PropertyDescriptor, ElementDescriptor, BehaviorOrName} from '../ast/ast';
 import {analyzeProperties} from './analyze-properties';
 import * as estree from 'estree';
 

--- a/src/ast-utils/descriptors.ts
+++ b/src/ast-utils/descriptors.ts
@@ -1,11 +1,15 @@
 /**
  * @license
  * Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
- * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
- * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
- * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
  * Code distributed by Google as part of the polymer project is also
- * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
  */
 
 'use strict';
@@ -13,7 +17,7 @@ import * as estree from 'estree';
 import * as jsdoc from './jsdoc';
 import * as dom5 from 'dom5';
 
-export type LiteralValue = string|number|boolean|RegExp;
+export type LiteralValue = string | number | boolean | RegExp;
 
 export interface Descriptor {
   jsdoc?: jsdoc.Annotation;
@@ -33,12 +37,12 @@ export interface PropertyDescriptor extends Descriptor {
   readOnly?: LiteralValue;
   reflectToAttribute?: LiteralValue;
   default?: LiteralValue;
-  private?: boolean;
-  configuration?: boolean;
-  getter?: boolean;
-  setter?: boolean;
+    private?: boolean;
+    configuration?: boolean;
+    getter?: boolean;
+    setter?: boolean;
 
-  __fromBehavior?: BehaviorOrName;
+    __fromBehavior?: BehaviorOrName;
 }
 
 /**
@@ -54,11 +58,8 @@ export interface ElementDescriptor extends Descriptor {
   }[];
   behaviors?: BehaviorOrName[];
 
-  type: string; // 'element' | 'behavior'
-  demos?: {
-    desc: string;
-    path: string;
-  }[];
+  type: string;  // 'element' | 'behavior'
+  demos?: {desc: string; path: string;}[];
   events?: EventDescriptor[];
   hero?: string;
   domModule?: dom5.Node;
@@ -77,28 +78,21 @@ export interface BehaviorDescriptor extends ElementDescriptor {
 export interface EventDescriptor extends Descriptor {
   name?: string;
   __fromBehavior?: BehaviorOrName;
-  params?: {
-    type: string,
-    desc: string,
-    name: string
-  }[];
+  params?: {type: string, desc: string, name: string}[];
 }
 
-export type BehaviorOrName = LiteralValue|BehaviorDescriptor;
+export type BehaviorOrName = LiteralValue | BehaviorDescriptor;
 
 export interface FunctionDescriptor extends PropertyDescriptor {
-  function: boolean; // true
-  return: {
-    type: string;
-    desc: string;
-  };
+  function: boolean;  // true
+  return: {type: string; desc: string;};
 }
 
 /**
  * The metadata for a Polymer feature.
  */
-export interface FeatureDescriptor extends ElementDescriptor {
+export interface FeatureDescriptor extends ElementDescriptor {}
 
-}
-
-export type BehaviorsByName = {[name: string]: BehaviorDescriptor};
+export type BehaviorsByName = {
+  [name: string]: BehaviorDescriptor
+};

--- a/src/ast-utils/descriptors.ts
+++ b/src/ast-utils/descriptors.ts
@@ -59,7 +59,7 @@ export interface ElementDescriptor extends Descriptor {
   behaviors?: BehaviorOrName[];
 
   type: string;  // 'element' | 'behavior'
-  demos?: {desc: string; path: string;}[];
+  demos?: {desc: string; path: string}[];
   events?: EventDescriptor[];
   hero?: string;
   domModule?: dom5.Node;
@@ -85,7 +85,7 @@ export type BehaviorOrName = LiteralValue | BehaviorDescriptor;
 
 export interface FunctionDescriptor extends PropertyDescriptor {
   function: boolean;  // true
-  return: {type: string; desc: string;};
+  return: {type: string; desc: string};
 }
 
 /**

--- a/src/ast-utils/docs.ts
+++ b/src/ast-utils/docs.ts
@@ -56,7 +56,8 @@ const HANDLED_TAGS = [
  * @return {Object} The descriptor that was given.
  */
 export function annotate(descriptor: Descriptor): Descriptor {
-  if (!descriptor || descriptor.jsdoc) return descriptor;
+  if (!descriptor || descriptor.jsdoc)
+    return descriptor;
 
   if (typeof descriptor.desc === 'string') {
     descriptor.jsdoc = jsdoc.parseJsdoc(descriptor.desc);
@@ -73,7 +74,9 @@ export function annotate(descriptor: Descriptor): Descriptor {
  */
 export function annotateElementHeader(descriptor: ElementDescriptor) {
   if (descriptor.events) {
-    descriptor.events.forEach(function(event) { _annotateEvent(event); });
+    descriptor.events.forEach(function(event) {
+      _annotateEvent(event);
+    });
     descriptor.events.sort(function(a, b) {
       return a.name.localeCompare(b.name);
     });
@@ -313,10 +316,12 @@ function _annotateFunctionProperty(descriptor: FunctionDescriptor) {
   }
 
   const paramsByName = {};
-  (descriptor.params ||
-   []).forEach((param) => { paramsByName[param.name] = param; });
+  (descriptor.params || []).forEach((param) => {
+    paramsByName[param.name] = param;
+  });
   (descriptor.jsdoc && descriptor.jsdoc.tags || []).forEach((tag) => {
-    if (tag.tag !== 'param') return;
+    if (tag.tag !== 'param')
+      return;
     const param = paramsByName[tag.name];
     if (!param) {
       return;
@@ -338,8 +343,10 @@ function _annotateFunctionProperty(descriptor: FunctionDescriptor) {
  */
 export function featureElement(features: FeatureDescriptor[]):
     ElementDescriptor {
-  const properties = features.reduce<PropertyDescriptor[]>(
-      (result, feature) => { return result.concat(feature.properties); }, []);
+  const properties =
+      features.reduce<PropertyDescriptor[]>((result, feature) => {
+        return result.concat(feature.properties);
+      }, []);
 
   return {
     type: 'element',
@@ -363,7 +370,8 @@ export function featureElement(features: FeatureDescriptor[]):
  * @param {Object} descriptor
  */
 export function clean(descriptor: Descriptor) {
-  if (!descriptor.jsdoc) return;
+  if (!descriptor.jsdoc)
+    return;
   // The doctext was written to `descriptor.desc`
   delete descriptor.jsdoc.description;
   delete descriptor.jsdoc.orig;
@@ -371,7 +379,8 @@ export function clean(descriptor: Descriptor) {
   const cleanTags: jsdoc.Tag[] = [];
   (descriptor.jsdoc.tags || []).forEach(function(tag) {
     // Drop any tags we've consumed.
-    if (HANDLED_TAGS.indexOf(tag.tag) !== -1) return;
+    if (HANDLED_TAGS.indexOf(tag.tag) !== -1)
+      return;
     cleanTags.push(tag);
   });
 
@@ -455,7 +464,8 @@ function _findElementDocs(
   if (comment && comment.data) {
     found.push(comment.data);
   }
-  if (found.length === 0) return null;
+  if (found.length === 0)
+    return null;
   return found
       .filter(function(comment) {
         // skip @license comments
@@ -473,7 +483,8 @@ function _findLastChildNamed(name: string, parent: dom5.Node) {
   const children = parent.childNodes;
   for (let i = children.length - 1; i >= 0; i--) {
     let child = children[i];
-    if (child.nodeName === name) return child;
+    if (child.nodeName === name)
+      return child;
   }
   return null;
 }

--- a/src/ast-utils/docs.ts
+++ b/src/ast-utils/docs.ts
@@ -1,11 +1,15 @@
 /**
  * @license
  * Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
- * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
- * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
- * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
  * Code distributed by Google as part of the polymer project is also
- * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
  */
 'use strict';
 
@@ -14,27 +18,21 @@
 import * as jsdoc from './jsdoc';
 import * as dom5 from 'dom5';
 import {
-  FeatureDescriptor, FunctionDescriptor, PropertyDescriptor, Descriptor,
-  ElementDescriptor, BehaviorsByName, EventDescriptor, BehaviorDescriptor
+  FeatureDescriptor,
+  FunctionDescriptor,
+  PropertyDescriptor,
+  Descriptor,
+  ElementDescriptor,
+  BehaviorsByName,
+  EventDescriptor,
+  BehaviorDescriptor
 } from '../ast/ast';
 
 /** Properties on element prototypes that are purely configuration. */
 const ELEMENT_CONFIGURATION = [
-  'attached',
-  'attributeChanged',
-  'beforeRegister',
-  'configure',
-  'constructor',
-  'created',
-  'detached',
-  'enableCustomStyleProperties',
-  'extends',
-  'hostAttributes',
-  'is',
-  'listeners',
-  'mixins',
-  'properties',
-  'ready',
+  'attached', 'attributeChanged', 'beforeRegister', 'configure', 'constructor',
+  'created', 'detached', 'enableCustomStyleProperties', 'extends',
+  'hostAttributes', 'is', 'listeners', 'mixins', 'properties', 'ready',
   'registered'
 ];
 
@@ -64,7 +62,7 @@ export function annotate(descriptor: Descriptor): Descriptor {
     descriptor.jsdoc = jsdoc.parseJsdoc(descriptor.desc);
     // We want to present the normalized form of a descriptor.
     descriptor.jsdoc.orig = descriptor.desc;
-    descriptor.desc       = descriptor.jsdoc.description;
+    descriptor.desc = descriptor.jsdoc.description;
   }
 
   return descriptor;
@@ -75,16 +73,14 @@ export function annotate(descriptor: Descriptor): Descriptor {
  */
 export function annotateElementHeader(descriptor: ElementDescriptor) {
   if (descriptor.events) {
-    descriptor.events.forEach(function(event) {
-      _annotateEvent(event);
-    });
-    descriptor.events.sort( function(a, b) {
+    descriptor.events.forEach(function(event) { _annotateEvent(event); });
+    descriptor.events.sort(function(a, b) {
       return a.name.localeCompare(b.name);
     });
   }
   descriptor.demos = [];
   if (descriptor.jsdoc && descriptor.jsdoc.tags) {
-    descriptor.jsdoc.tags.forEach( function(tag) {
+    descriptor.jsdoc.tags.forEach(function(tag) {
       switch (tag.tag) {
         case 'hero':
           descriptor.hero = tag.name || 'hero.png';
@@ -104,9 +100,9 @@ function copyProperties(
     from: ElementDescriptor, to: ElementDescriptor,
     behaviorsByName: BehaviorsByName) {
   if (from.properties) {
-    from.properties.forEach(function(fromProp){
-      for (let toProp: PropertyDescriptor, i = 0;
-           i < to.properties.length; i++) {
+    from.properties.forEach(function(fromProp) {
+      for (let toProp: PropertyDescriptor, i = 0; i < to.properties.length;
+           i++) {
         toProp = to.properties[i];
         if (fromProp.name === toProp.name) {
           return;
@@ -116,12 +112,12 @@ function copyProperties(
       if (fromProp.__fromBehavior) {
         return;
       }
-      Object.keys(fromProp).forEach(function(propertyField){
+      Object.keys(fromProp).forEach(function(propertyField) {
         newProp[propertyField] = fromProp[propertyField];
       });
       to.properties.push(<any>newProp);
     });
-    from.events.forEach(function(fromEvent){
+    from.events.forEach(function(fromEvent) {
       for (let toEvent: EventDescriptor, i = 0; i < to.events.length; i++) {
         toEvent = to.events[i];
         if (fromEvent.name === toEvent.name) {
@@ -132,7 +128,7 @@ function copyProperties(
         return;
       }
       const newEvent = {__fromBehavior: from.is};
-      Object.keys(fromEvent).forEach(function(eventField){
+      Object.keys(fromEvent).forEach(function(eventField) {
         newEvent[eventField] = fromEvent[eventField];
       });
       to.events.push(newEvent);
@@ -148,10 +144,10 @@ function copyProperties(
     const definedBehavior =
         behaviorsByName[localBehavior] || behaviorsByName[localBehavior.symbol];
     if (!definedBehavior) {
-        console.warn(
-            `Behavior ${localBehavior} not found when mixing ` +
-            `properties into ${to.is}!`);
-        return;
+      console.warn(
+          `Behavior ${localBehavior} not found when mixing ` +
+          `properties into ${to.is}!`);
+      return;
     }
     copyProperties(definedBehavior, to, behaviorsByName);
   }
@@ -188,9 +184,8 @@ export function annotateElement(
     descriptor: ElementDescriptor,
     behaviorsByName: BehaviorsByName): ElementDescriptor {
   if (!descriptor.desc && descriptor.type === 'element') {
-    descriptor.desc = _findElementDocs(descriptor.is,
-                                       descriptor.domModule,
-                                       descriptor.scriptElement);
+    descriptor.desc = _findElementDocs(
+        descriptor.is, descriptor.domModule, descriptor.scriptElement);
   }
   annotate(descriptor);
 
@@ -218,7 +213,7 @@ export function annotateElement(
       return 1;
     } else if (!a.private && b.private) {
       return -1;
-    // Otherwise, we're just sorting alphabetically.
+      // Otherwise, we're just sorting alphabetically.
     } else {
       return a.name.localeCompare(b.name);
     }
@@ -234,8 +229,8 @@ export function annotateElement(
  * @param {Object} descriptor behavior descriptor
  * @return {Object} descriptor passed in as param
  */
-export function annotateBehavior(
-    descriptor: BehaviorDescriptor): BehaviorDescriptor {
+export function annotateBehavior(descriptor: BehaviorDescriptor):
+    BehaviorDescriptor {
   annotate(descriptor);
   annotateElementHeader(descriptor);
 
@@ -251,18 +246,16 @@ function _annotateEvent(descriptor: EventDescriptor): EventDescriptor {
   const eventTag = jsdoc.getTag(descriptor.jsdoc, 'event');
   descriptor.name = eventTag ? eventTag.description : 'N/A';
 
+  const tags = (descriptor.jsdoc.tags || []);
   // process @params
-  descriptor.params = (descriptor.jsdoc.tags || [])
-    .filter(function(tag) {
-      return tag.tag === 'param';
-    })
-    .map(function(tag) {
-      return {
-        type: tag.type || 'N/A',
-        desc: tag.description,
-        name: tag.name || 'N/A'
-      };
-    });
+  descriptor.params =
+      tags.filter((tag) => tag.tag === 'param').map(function(param) {
+        return {
+          type: param.type || 'N/A',
+          desc: param.description,
+          name: param.name || 'N/A'
+        };
+      });
   // process @params
   return descriptor;
 }
@@ -284,7 +277,7 @@ function annotateProperty(
 
   if (!ignoreConfiguration &&
       ELEMENT_CONFIGURATION.indexOf(descriptor.name) !== -1) {
-    descriptor.private       = true;
+    descriptor.private = true;
     descriptor.configuration = true;
   }
 
@@ -320,10 +313,9 @@ function _annotateFunctionProperty(descriptor: FunctionDescriptor) {
   }
 
   const paramsByName = {};
-  (descriptor.params || []).forEach(function(param) {
-    paramsByName[param.name] = param;
-  });
-  (descriptor.jsdoc && descriptor.jsdoc.tags || []).forEach(function(tag) {
+  (descriptor.params ||
+   []).forEach((param) => { paramsByName[param.name] = param; });
+  (descriptor.jsdoc && descriptor.jsdoc.tags || []).forEach((tag) => {
     if (tag.tag !== 'param') return;
     const param = paramsByName[tag.name];
     if (!param) {
@@ -344,24 +336,23 @@ function _annotateFunctionProperty(descriptor: FunctionDescriptor) {
  * @param {Array<FeatureDescriptor>} features
  * @return {ElementDescriptor}
  */
-export function featureElement(
-    features: FeatureDescriptor[]): ElementDescriptor {
-  const properties = features.reduce<PropertyDescriptor[]>((result, feature) => {
-    return result.concat(feature.properties);
-  }, []);
+export function featureElement(features: FeatureDescriptor[]):
+    ElementDescriptor {
+  const properties = features.reduce<PropertyDescriptor[]>(
+      (result, feature) => { return result.concat(feature.properties); }, []);
 
   return {
-    type:       'element',
-    is:         'Polymer.Base',
-    abstract:   true,
+    type: 'element',
+    is: 'Polymer.Base',
+    abstract: true,
     properties: properties,
     desc: '`Polymer.Base` acts as a base prototype for all Polymer ' +
-          'elements. It is composed via various calls to ' +
-          '`Polymer.Base._addFeature()`.\n' +
-          '\n' +
-          'The properties reflected here are the combined view of all ' +
-          'features found in this library. There may be more properties ' +
-          'added via other libraries, as well.',
+        'elements. It is composed via various calls to ' +
+        '`Polymer.Base._addFeature()`.\n' +
+        '\n' +
+        'The properties reflected here are the combined view of all ' +
+        'features found in this library. There may be more properties ' +
+        'added via other libraries, as well.',
   };
 }
 
@@ -466,16 +457,16 @@ function _findElementDocs(
   }
   if (found.length === 0) return null;
   return found
-    .filter(function(comment) {
-      // skip @license comments
-      if (comment && comment.indexOf('@license') === -1) {
-        return true;
-      }
-      else {
-        return false;
-      }
-    })
-    .map(jsdoc.unindent).join('\n');
+      .filter(function(comment) {
+        // skip @license comments
+        if (comment && comment.indexOf('@license') === -1) {
+          return true;
+        } else {
+          return false;
+        }
+      })
+      .map(jsdoc.unindent)
+      .join('\n');
 }
 
 function _findLastChildNamed(name: string, parent: dom5.Node) {

--- a/src/ast-utils/docs.ts
+++ b/src/ast-utils/docs.ts
@@ -17,16 +17,7 @@
 
 import * as jsdoc from './jsdoc';
 import * as dom5 from 'dom5';
-import {
-  FeatureDescriptor,
-  FunctionDescriptor,
-  PropertyDescriptor,
-  Descriptor,
-  ElementDescriptor,
-  BehaviorsByName,
-  EventDescriptor,
-  BehaviorDescriptor
-} from '../ast/ast';
+import {FeatureDescriptor, FunctionDescriptor, PropertyDescriptor, Descriptor, ElementDescriptor, BehaviorsByName, EventDescriptor, BehaviorDescriptor} from '../ast/ast';
 
 /** Properties on element prototypes that are purely configuration. */
 const ELEMENT_CONFIGURATION = [

--- a/src/ast-utils/element-finder.ts
+++ b/src/ast-utils/element-finder.ts
@@ -18,10 +18,7 @@ import * as estraverse from 'estraverse';
 import * as esutil from './esutil';
 import * as analyzeProperties from './analyze-properties';
 import * as astValue from './ast-value';
-import {
-  declarationPropertyHandlers,
-  PropertyHandlers
-} from './declaration-property-handlers';
+import {declarationPropertyHandlers, PropertyHandlers} from './declaration-property-handlers';
 import {ElementDescriptor, PropertyDescriptor} from '../ast/ast';
 import {Visitor} from './fluent-traverse';
 import * as estree from 'estree';

--- a/src/ast-utils/element-finder.ts
+++ b/src/ast-utils/element-finder.ts
@@ -1,11 +1,15 @@
 /**
  * @license
  * Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
- * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
- * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
- * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
  * Code distributed by Google as part of the polymer project is also
- * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
  */
 
 'use strict';
@@ -14,7 +18,10 @@ import * as estraverse from 'estraverse';
 import * as esutil from './esutil';
 import * as analyzeProperties from './analyze-properties';
 import * as astValue from './ast-value';
-import {declarationPropertyHandlers, PropertyHandlers} from './declaration-property-handlers';
+import {
+  declarationPropertyHandlers,
+  PropertyHandlers
+} from './declaration-property-handlers';
 import {ElementDescriptor, PropertyDescriptor} from '../ast/ast';
 import {Visitor} from './fluent-traverse';
 import * as estree from 'estree';
@@ -41,9 +48,7 @@ export function elementFinder() {
       element = {
         type: 'element',
         desc: esutil.getAttachedComment(node),
-        events: esutil.getEventComments(node).map(function(event) {
-          return { desc: event };
-        }),
+        events: esutil.getEventComments(node).map((event) => ({desc: event})),
         properties: [],
         behaviors: [],
         observers: []
@@ -61,7 +66,7 @@ export function elementFinder() {
       this.classDetected = false;
     },
 
-    enterAssignmentExpression: function enterAssignmentExpression(node, parent) {
+    enterAssignmentExpression(node, parent) {
       if (!element) {
         return;
       }
@@ -78,7 +83,7 @@ export function elementFinder() {
       }
     },
 
-    enterMethodDefinition: function enterMethodDefinition(node, parent) {
+    enterMethodDefinition(node, parent) {
       if (!element) {
         return;
       }
@@ -92,8 +97,10 @@ export function elementFinder() {
         computed: false,
         type: 'Property'
       };
-      const propDesc = <PropertyDescriptor>docs.annotate(esutil.toPropertyDescriptor(prop));
-      if (prop && prop.kind === 'get' && (propDesc.name === 'behaviors' || propDesc.name === 'observers')) {
+      const propDesc =
+          <PropertyDescriptor>docs.annotate(esutil.toPropertyDescriptor(prop));
+      if (prop && prop.kind === 'get' &&
+          (propDesc.name === 'behaviors' || propDesc.name === 'observers')) {
         const returnStatement = <estree.ReturnStatement>node.value.body.body[0];
         const argument = <estree.ArrayExpression>returnStatement.argument;
         if (propDesc.name === 'behaviors') {
@@ -102,7 +109,8 @@ export function elementFinder() {
           });
         } else {
           argument.elements.forEach((elementObject: estree.Literal) => {
-            element.observers.push({ javascriptNode: elementObject, expression: elementObject.raw });
+            element.observers.push(
+                {javascriptNode: elementObject, expression: elementObject.raw});
           });
         }
       } else {
@@ -110,8 +118,9 @@ export function elementFinder() {
       }
     },
 
-    enterCallExpression: function enterCallExpression(node, parent) {
-      // When dealing with a class, enterCallExpression is called after the parsing actually starts
+    enterCallExpression(node, parent) {
+      // When dealing with a class, enterCallExpression is called after the
+      // parsing actually starts
       if (this.classDetected) {
         return estraverse.VisitorOption.Skip;
       }
@@ -122,9 +131,8 @@ export function elementFinder() {
           element = {
             type: 'element',
             desc: esutil.getAttachedComment(parent),
-            events: esutil.getEventComments(parent).map( function(event) {
-              return {desc: event};
-            })
+            events: esutil.getEventComments(parent).map(
+                (event) => ({desc: event}))
           };
           propertyHandlers = declarationPropertyHandlers(element);
         }
@@ -134,7 +142,8 @@ export function elementFinder() {
     leaveCallExpression: function leaveCallExpression(node, parent) {
       const callee = node.callee;
       const args = node.arguments;
-      if (callee.type === 'Identifier' && args.length === 1 && args[0].type === 'ObjectExpression') {
+      if (callee.type === 'Identifier' && args.length === 1 &&
+          args[0].type === 'ObjectExpression') {
         if (callee.name === 'Polymer') {
           if (element) {
             elements.push(element);
@@ -146,7 +155,8 @@ export function elementFinder() {
     },
 
     enterObjectExpression: function enterObjectExpression(node, parent) {
-      // When dealing with a class, there is no single object that we can parse to retrieve all properties
+      // When dealing with a class, there is no single object that we can parse
+      // to retrieve all properties
       if (this.classDetected) {
         return estraverse.VisitorOption.Skip;
       }
@@ -193,7 +203,7 @@ export function elementFinder() {
             definedProperties[set.name].setter = true;
           }
         });
-        Object.keys(definedProperties).forEach(function(p){
+        Object.keys(definedProperties).forEach(function(p) {
           const prop = definedProperties[p];
           element.properties.push(prop);
         });

--- a/src/ast-utils/esutil.ts
+++ b/src/ast-utils/esutil.ts
@@ -1,11 +1,15 @@
 /**
  * @license
  * Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
- * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
- * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
- * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
  * Code distributed by Google as part of the polymer project is also
- * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
  */
 
 'use strict';
@@ -25,7 +29,8 @@ import {BehaviorDescriptor, PropertyDescriptor} from '../ast/ast';
  * @param {ESTree.Node} expression The Espree node to match against.
  * @param {Array<string>} path The path to look for.
  */
-export function matchesCallExpression(expression: estree.MemberExpression, path: string[]): boolean {
+export function matchesCallExpression(
+    expression: estree.MemberExpression, path: string[]): boolean {
   if (!expression.property || !expression.object) return;
   console.assert(path.length >= 2);
 
@@ -59,14 +64,15 @@ export function objectKeyToString(key: estree.Node): string {
     return key.value.toString();
   }
   if (key.type === 'MemberExpression') {
-    return objectKeyToString(key.object) + '.' + objectKeyToString(key.property);
+    return objectKeyToString(key.object) + '.' +
+        objectKeyToString(key.property);
   }
 }
 
 const CLOSURE_CONSTRUCTOR_MAP = {
   'Boolean': 'boolean',
-  'Number':  'number',
-  'String':  'string',
+  'Number': 'number',
+  'String': 'string',
 };
 
 /**
@@ -107,23 +113,18 @@ export function getEventComments(node: estree.Node) {
   let eventComments: string[] = [];
   estraverse.traverse(node, {
     enter: (node) => {
-      const comments = (node.leadingComments || []).concat(node.trailingComments || [])
-        .map(function(commentAST) {
-          return commentAST.value;
-        })
-        .filter( function(comment) {
-          return comment.indexOf('@event') !== -1;
-        });
+      const comments =
+          (node.leadingComments || [])
+              .concat(node.trailingComments || [])
+              .map((commentAST) => commentAST.value)
+              .filter((comment) => comment.indexOf('@event') !== -1);
       eventComments = eventComments.concat(comments);
     },
-    keys: {
-      Super: []
-    }
+    keys: {Super: []}
   });
   // dedup
-  return eventComments.filter((el, index, array) => {
-    return array.indexOf(el) === index;
-  });
+  return eventComments.filter(
+      (el, index, array) => { return array.indexOf(el) === index; });
 }
 
 function getLeadingComments(node: estree.Node): string[] {
@@ -132,15 +133,14 @@ function getLeadingComments(node: estree.Node): string[] {
   }
   const comments = node.leadingComments;
   if (!comments || comments.length === 0) return;
-  return comments.map(function(comment) {
-    return comment.value;
-  });
+  return comments.map(function(comment) { return comment.value; });
 }
 
 /**
  * Converts a estree Property AST node into its Hydrolysis representation.
  */
-export function toPropertyDescriptor(node: estree.Property): PropertyDescriptor {
+export function toPropertyDescriptor(node: estree.Property):
+    PropertyDescriptor {
   let type = closureType(node.value);
   if (type === 'Function') {
     if (node.kind === 'get' || node.kind === 'set') {

--- a/src/ast-utils/esutil.ts
+++ b/src/ast-utils/esutil.ts
@@ -31,14 +31,16 @@ import {BehaviorDescriptor, PropertyDescriptor} from '../ast/ast';
  */
 export function matchesCallExpression(
     expression: estree.MemberExpression, path: string[]): boolean {
-  if (!expression.property || !expression.object) return;
+  if (!expression.property || !expression.object)
+    return;
   console.assert(path.length >= 2);
 
   if (expression.property.type !== 'Identifier') {
     return;
   }
   // Unravel backwards, make sure properties match each step of the way.
-  if (expression.property.name !== path[path.length - 1]) return false;
+  if (expression.property.name !== path[path.length - 1])
+    return false;
   // We've got ourselves a final member expression.
   if (path.length === 2 && expression.object.type === 'Identifier') {
     return expression.object.name === path[0];
@@ -123,8 +125,9 @@ export function getEventComments(node: estree.Node) {
     keys: {Super: []}
   });
   // dedup
-  return eventComments.filter(
-      (el, index, array) => { return array.indexOf(el) === index; });
+  return eventComments.filter((el, index, array) => {
+    return array.indexOf(el) === index;
+  });
 }
 
 function getLeadingComments(node: estree.Node): string[] {
@@ -132,8 +135,11 @@ function getLeadingComments(node: estree.Node): string[] {
     return;
   }
   const comments = node.leadingComments;
-  if (!comments || comments.length === 0) return;
-  return comments.map(function(comment) { return comment.value; });
+  if (!comments || comments.length === 0)
+    return;
+  return comments.map(function(comment) {
+    return comment.value;
+  });
 }
 
 /**

--- a/src/ast-utils/feature-finder.ts
+++ b/src/ast-utils/feature-finder.ts
@@ -1,11 +1,15 @@
 /**
  * @license
  * Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
- * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
- * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
- * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
  * Code distributed by Google as part of the polymer project is also
- * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
  */
 
 'use strict';
@@ -42,15 +46,16 @@ export function featureFinder() {
       return;
     }
 
-    feature.properties = featureNode.properties.map(esutil.toPropertyDescriptor);
+    feature.properties =
+        featureNode.properties.map(esutil.toPropertyDescriptor);
   }
 
   const visitors: Visitor = {
 
     enterCallExpression: function enterCallExpression(node, parent) {
       const isAddFeatureCall = esutil.matchesCallExpression(
-            <estree.MemberExpression>node.callee,
-            ['Polymer', 'Base', '_addFeature']);
+          <estree.MemberExpression>node.callee,
+          ['Polymer', 'Base', '_addFeature']);
       if (!isAddFeatureCall) {
         return;
       }

--- a/src/ast-utils/fluent-traverse.ts
+++ b/src/ast-utils/fluent-traverse.ts
@@ -12,44 +12,66 @@ export interface Visitor {
   enterProgram?: (node: estree.Program, parent: estree.Node) => void;
   leaveProgram?: (node: estree.Program, parent: estree.Node) => void;
 
-  enterExpressionStatement?: (node: estree.ExpressionStatement, parent: estree.Node) => void;
-  leaveExpressionStatement?: (node: estree.ExpressionStatement, parent: estree.Node) => void;
+  enterExpressionStatement?:
+      (node: estree.ExpressionStatement, parent: estree.Node) => void;
+  leaveExpressionStatement?:
+      (node: estree.ExpressionStatement, parent: estree.Node) => void;
 
-  enterBlockStatement?: (node: estree.BlockStatement, parent: estree.Node) => void;
-  leaveBlockStatement?: (node: estree.BlockStatement, parent: estree.Node) => void;
+  enterBlockStatement?:
+      (node: estree.BlockStatement, parent: estree.Node) => void;
+  leaveBlockStatement?:
+      (node: estree.BlockStatement, parent: estree.Node) => void;
 
-  enterEmptyStatement?: (node: estree.EmptyStatement, parent: estree.Node) => void;
-  leaveEmptyStatement?: (node: estree.EmptyStatement, parent: estree.Node) => void;
+  enterEmptyStatement?:
+      (node: estree.EmptyStatement, parent: estree.Node) => void;
+  leaveEmptyStatement?:
+      (node: estree.EmptyStatement, parent: estree.Node) => void;
 
-  enterDebuggerStatement?: (node: estree.DebuggerStatement, parent: estree.Node) => void;
-  leaveDebuggerStatement?: (node: estree.DebuggerStatement, parent: estree.Node) => void;
+  enterDebuggerStatement?:
+      (node: estree.DebuggerStatement, parent: estree.Node) => void;
+  leaveDebuggerStatement?:
+      (node: estree.DebuggerStatement, parent: estree.Node) => void;
 
-  enterWithStatement?: (node: estree.WithStatement, parent: estree.Node) => void;
-  leaveWithStatement?: (node: estree.WithStatement, parent: estree.Node) => void;
+  enterWithStatement?:
+      (node: estree.WithStatement, parent: estree.Node) => void;
+  leaveWithStatement?:
+      (node: estree.WithStatement, parent: estree.Node) => void;
 
-  enterReturnStatement?: (node: estree.ReturnStatement, parent: estree.Node) => void;
-  leaveReturnStatement?: (node: estree.ReturnStatement, parent: estree.Node) => void;
+  enterReturnStatement?:
+      (node: estree.ReturnStatement, parent: estree.Node) => void;
+  leaveReturnStatement?:
+      (node: estree.ReturnStatement, parent: estree.Node) => void;
 
-  enterLabeledStatement?: (node: estree.LabeledStatement, parent: estree.Node) => void;
-  leaveLabeledStatement?: (node: estree.LabeledStatement, parent: estree.Node) => void;
+  enterLabeledStatement?:
+      (node: estree.LabeledStatement, parent: estree.Node) => void;
+  leaveLabeledStatement?:
+      (node: estree.LabeledStatement, parent: estree.Node) => void;
 
-  enterBreakStatement?: (node: estree.BreakStatement, parent: estree.Node) => void;
-  leaveBreakStatement?: (node: estree.BreakStatement, parent: estree.Node) => void;
+  enterBreakStatement?:
+      (node: estree.BreakStatement, parent: estree.Node) => void;
+  leaveBreakStatement?:
+      (node: estree.BreakStatement, parent: estree.Node) => void;
 
-  enterContinueStatement?: (node: estree.ContinueStatement, parent: estree.Node) => void;
-  leaveContinueStatement?: (node: estree.ContinueStatement, parent: estree.Node) => void;
+  enterContinueStatement?:
+      (node: estree.ContinueStatement, parent: estree.Node) => void;
+  leaveContinueStatement?:
+      (node: estree.ContinueStatement, parent: estree.Node) => void;
 
   enterIfStatement?: (node: estree.IfStatement, parent: estree.Node) => void;
   leaveIfStatement?: (node: estree.IfStatement, parent: estree.Node) => void;
 
-  enterSwitchStatement?: (node: estree.SwitchStatement, parent: estree.Node) => void;
-  leaveSwitchStatement?: (node: estree.SwitchStatement, parent: estree.Node) => void;
+  enterSwitchStatement?:
+      (node: estree.SwitchStatement, parent: estree.Node) => void;
+  leaveSwitchStatement?:
+      (node: estree.SwitchStatement, parent: estree.Node) => void;
 
   enterSwitchCase?: (node: estree.SwitchCase, parent: estree.Node) => void;
   leaveSwitchCase?: (node: estree.SwitchCase, parent: estree.Node) => void;
 
-  enterThrowStatement?: (node: estree.ThrowStatement, parent: estree.Node) => void;
-  leaveThrowStatement?: (node: estree.ThrowStatement, parent: estree.Node) => void;
+  enterThrowStatement?:
+      (node: estree.ThrowStatement, parent: estree.Node) => void;
+  leaveThrowStatement?:
+      (node: estree.ThrowStatement, parent: estree.Node) => void;
 
   enterTryStatement?: (node: estree.TryStatement, parent: estree.Node) => void;
   leaveTryStatement?: (node: estree.TryStatement, parent: estree.Node) => void;
@@ -57,104 +79,162 @@ export interface Visitor {
   enterCatchClause?: (node: estree.CatchClause, parent: estree.Node) => void;
   leaveCatchClause?: (node: estree.CatchClause, parent: estree.Node) => void;
 
-  enterWhileStatement?: (node: estree.WhileStatement, parent: estree.Node) => void;
-  leaveWhileStatement?: (node: estree.WhileStatement, parent: estree.Node) => void;
+  enterWhileStatement?:
+      (node: estree.WhileStatement, parent: estree.Node) => void;
+  leaveWhileStatement?:
+      (node: estree.WhileStatement, parent: estree.Node) => void;
 
-  enterDoWhileStatement?: (node: estree.DoWhileStatement, parent: estree.Node) => void;
-  leaveDoWhileStatement?: (node: estree.DoWhileStatement, parent: estree.Node) => void;
+  enterDoWhileStatement?:
+      (node: estree.DoWhileStatement, parent: estree.Node) => void;
+  leaveDoWhileStatement?:
+      (node: estree.DoWhileStatement, parent: estree.Node) => void;
 
   enterForStatement?: (node: estree.ForStatement, parent: estree.Node) => void;
   leaveForStatement?: (node: estree.ForStatement, parent: estree.Node) => void;
 
-  enterForInStatement?: (node: estree.ForInStatement, parent: estree.Node) => void;
-  leaveForInStatement?: (node: estree.ForInStatement, parent: estree.Node) => void;
+  enterForInStatement?:
+      (node: estree.ForInStatement, parent: estree.Node) => void;
+  leaveForInStatement?:
+      (node: estree.ForInStatement, parent: estree.Node) => void;
 
-  enterForOfStatement?: (node: estree.ForOfStatement, parent: estree.Node) => void;
-  leaveForOfStatement?: (node: estree.ForOfStatement, parent: estree.Node) => void;
+  enterForOfStatement?:
+      (node: estree.ForOfStatement, parent: estree.Node) => void;
+  leaveForOfStatement?:
+      (node: estree.ForOfStatement, parent: estree.Node) => void;
 
-  enterFunctionDeclaration?: (node: estree.FunctionDeclaration, parent: estree.Node) => void;
-  leaveFunctionDeclaration?: (node: estree.FunctionDeclaration, parent: estree.Node) => void;
+  enterFunctionDeclaration?:
+      (node: estree.FunctionDeclaration, parent: estree.Node) => void;
+  leaveFunctionDeclaration?:
+      (node: estree.FunctionDeclaration, parent: estree.Node) => void;
 
-  enterVariableDeclaration?: (node: estree.VariableDeclaration, parent: estree.Node) => void;
-  leaveVariableDeclaration?: (node: estree.VariableDeclaration, parent: estree.Node) => void;
+  enterVariableDeclaration?:
+      (node: estree.VariableDeclaration, parent: estree.Node) => void;
+  leaveVariableDeclaration?:
+      (node: estree.VariableDeclaration, parent: estree.Node) => void;
 
-  enterVariableDeclarator?: (node: estree.VariableDeclarator, parent: estree.Node) => void;
-  leaveVariableDeclarator?: (node: estree.VariableDeclarator, parent: estree.Node) => void;
+  enterVariableDeclarator?:
+      (node: estree.VariableDeclarator, parent: estree.Node) => void;
+  leaveVariableDeclarator?:
+      (node: estree.VariableDeclarator, parent: estree.Node) => void;
 
-  enterThisExpression?: (node: estree.ThisExpression, parent: estree.Node) => void;
-  leaveThisExpression?: (node: estree.ThisExpression, parent: estree.Node) => void;
+  enterThisExpression?:
+      (node: estree.ThisExpression, parent: estree.Node) => void;
+  leaveThisExpression?:
+      (node: estree.ThisExpression, parent: estree.Node) => void;
 
-  enterArrayExpression?: (node: estree.ArrayExpression, parent: estree.Node) => void;
-  leaveArrayExpression?: (node: estree.ArrayExpression, parent: estree.Node) => void;
+  enterArrayExpression?:
+      (node: estree.ArrayExpression, parent: estree.Node) => void;
+  leaveArrayExpression?:
+      (node: estree.ArrayExpression, parent: estree.Node) => void;
 
-  enterObjectExpression?: (node: estree.ObjectExpression, parent: estree.Node) => void;
-  leaveObjectExpression?: (node: estree.ObjectExpression, parent: estree.Node) => void;
+  enterObjectExpression?:
+      (node: estree.ObjectExpression, parent: estree.Node) => void;
+  leaveObjectExpression?:
+      (node: estree.ObjectExpression, parent: estree.Node) => void;
 
   enterProperty?: (node: estree.Property, parent: estree.Node) => void;
   leaveProperty?: (node: estree.Property, parent: estree.Node) => void;
 
-  enterFunctionExpression?: (node: estree.FunctionExpression, parent: estree.Node) => void;
-  leaveFunctionExpression?: (node: estree.FunctionExpression, parent: estree.Node) => void;
+  enterFunctionExpression?:
+      (node: estree.FunctionExpression, parent: estree.Node) => void;
+  leaveFunctionExpression?:
+      (node: estree.FunctionExpression, parent: estree.Node) => void;
 
-  enterArrowFunctionExpression?: (node: estree.ArrowFunctionExpression, parent: estree.Node) => void;
-  leaveArrowFunctionExpression?: (node: estree.ArrowFunctionExpression, parent: estree.Node) => void;
+  enterArrowFunctionExpression?:
+      (node: estree.ArrowFunctionExpression, parent: estree.Node) => void;
+  leaveArrowFunctionExpression?:
+      (node: estree.ArrowFunctionExpression, parent: estree.Node) => void;
 
-  enterYieldExpression?: (node: estree.YieldExpression, parent: estree.Node) => void;
-  leaveYieldExpression?: (node: estree.YieldExpression, parent: estree.Node) => void;
+  enterYieldExpression?:
+      (node: estree.YieldExpression, parent: estree.Node) => void;
+  leaveYieldExpression?:
+      (node: estree.YieldExpression, parent: estree.Node) => void;
 
   enterSuper?: (node: estree.Super, parent: estree.Node) => void;
   leaveSuper?: (node: estree.Super, parent: estree.Node) => void;
 
-  enterUnaryExpression?: (node: estree.UnaryExpression, parent: estree.Node) => void;
-  leaveUnaryExpression?: (node: estree.UnaryExpression, parent: estree.Node) => void;
+  enterUnaryExpression?:
+      (node: estree.UnaryExpression, parent: estree.Node) => void;
+  leaveUnaryExpression?:
+      (node: estree.UnaryExpression, parent: estree.Node) => void;
 
-  enterUpdateExpression?: (node: estree.UpdateExpression, parent: estree.Node) => void;
-  leaveUpdateExpression?: (node: estree.UpdateExpression, parent: estree.Node) => void;
+  enterUpdateExpression?:
+      (node: estree.UpdateExpression, parent: estree.Node) => void;
+  leaveUpdateExpression?:
+      (node: estree.UpdateExpression, parent: estree.Node) => void;
 
-  enterBinaryExpression?: (node: estree.BinaryExpression, parent: estree.Node) => void;
-  leaveBinaryExpression?: (node: estree.BinaryExpression, parent: estree.Node) => void;
+  enterBinaryExpression?:
+      (node: estree.BinaryExpression, parent: estree.Node) => void;
+  leaveBinaryExpression?:
+      (node: estree.BinaryExpression, parent: estree.Node) => void;
 
-  enterAssignmentExpression?: (node: estree.AssignmentExpression, parent: estree.Node) => void;
-  leaveAssignmentExpression?: (node: estree.AssignmentExpression, parent: estree.Node) => void;
+  enterAssignmentExpression?:
+      (node: estree.AssignmentExpression, parent: estree.Node) => void;
+  leaveAssignmentExpression?:
+      (node: estree.AssignmentExpression, parent: estree.Node) => void;
 
-  enterLogicalExpression?: (node: estree.LogicalExpression, parent: estree.Node) => void;
-  leaveLogicalExpression?: (node: estree.LogicalExpression, parent: estree.Node) => void;
+  enterLogicalExpression?:
+      (node: estree.LogicalExpression, parent: estree.Node) => void;
+  leaveLogicalExpression?:
+      (node: estree.LogicalExpression, parent: estree.Node) => void;
 
-  enterMemberExpression?: (node: estree.MemberExpression, parent: estree.Node) => void;
-  leaveMemberExpression?: (node: estree.MemberExpression, parent: estree.Node) => void;
+  enterMemberExpression?:
+      (node: estree.MemberExpression, parent: estree.Node) => void;
+  leaveMemberExpression?:
+      (node: estree.MemberExpression, parent: estree.Node) => void;
 
-  enterConditionalExpression?: (node: estree.ConditionalExpression, parent: estree.Node) => void;
-  leaveConditionalExpression?: (node: estree.ConditionalExpression, parent: estree.Node) => void;
+  enterConditionalExpression?:
+      (node: estree.ConditionalExpression, parent: estree.Node) => void;
+  leaveConditionalExpression?:
+      (node: estree.ConditionalExpression, parent: estree.Node) => void;
 
-  enterCallExpression?: (node: estree.CallExpression, parent: estree.Node) => void;
-  leaveCallExpression?: (node: estree.CallExpression, parent: estree.Node) => void;
+  enterCallExpression?:
+      (node: estree.CallExpression, parent: estree.Node) => void;
+  leaveCallExpression?:
+      (node: estree.CallExpression, parent: estree.Node) => void;
 
-  enterNewExpression?: (node: estree.NewExpression, parent: estree.Node) => void;
-  leaveNewExpression?: (node: estree.NewExpression, parent: estree.Node) => void;
+  enterNewExpression?:
+      (node: estree.NewExpression, parent: estree.Node) => void;
+  leaveNewExpression?:
+      (node: estree.NewExpression, parent: estree.Node) => void;
 
-  enterSequenceExpression?: (node: estree.SequenceExpression, parent: estree.Node) => void;
-  leaveSequenceExpression?: (node: estree.SequenceExpression, parent: estree.Node) => void;
+  enterSequenceExpression?:
+      (node: estree.SequenceExpression, parent: estree.Node) => void;
+  leaveSequenceExpression?:
+      (node: estree.SequenceExpression, parent: estree.Node) => void;
 
-  enterTemplateLiteral?: (node: estree.TemplateLiteral, parent: estree.Node) => void;
-  leaveTemplateLiteral?: (node: estree.TemplateLiteral, parent: estree.Node) => void;
+  enterTemplateLiteral?:
+      (node: estree.TemplateLiteral, parent: estree.Node) => void;
+  leaveTemplateLiteral?:
+      (node: estree.TemplateLiteral, parent: estree.Node) => void;
 
-  enterTaggedTemplateExpression?: (node: estree.TaggedTemplateExpression, parent: estree.Node) => void;
-  leaveTaggedTemplateExpression?: (node: estree.TaggedTemplateExpression, parent: estree.Node) => void;
+  enterTaggedTemplateExpression?:
+      (node: estree.TaggedTemplateExpression, parent: estree.Node) => void;
+  leaveTaggedTemplateExpression?:
+      (node: estree.TaggedTemplateExpression, parent: estree.Node) => void;
 
-  enterTemplateElement?: (node: estree.TemplateElement, parent: estree.Node) => void;
-  leaveTemplateElement?: (node: estree.TemplateElement, parent: estree.Node) => void;
+  enterTemplateElement?:
+      (node: estree.TemplateElement, parent: estree.Node) => void;
+  leaveTemplateElement?:
+      (node: estree.TemplateElement, parent: estree.Node) => void;
 
-  enterSpreadElement?: (node: estree.SpreadElement, parent: estree.Node) => void;
-  leaveSpreadElement?: (node: estree.SpreadElement, parent: estree.Node) => void;
+  enterSpreadElement?:
+      (node: estree.SpreadElement, parent: estree.Node) => void;
+  leaveSpreadElement?:
+      (node: estree.SpreadElement, parent: estree.Node) => void;
 
   enterPattern?: (node: estree.Pattern, parent: estree.Node) => void;
   leavePattern?: (node: estree.Pattern, parent: estree.Node) => void;
 
-  enterAssignmentProperty?: (node: estree.AssignmentProperty, parent: estree.Node) => void;
-  leaveAssignmentProperty?: (node: estree.AssignmentProperty, parent: estree.Node) => void;
+  enterAssignmentProperty?:
+      (node: estree.AssignmentProperty, parent: estree.Node) => void;
+  leaveAssignmentProperty?:
+      (node: estree.AssignmentProperty, parent: estree.Node) => void;
 
-  enterObjectPattern?: (node: estree.ObjectPattern, parent: estree.Node) => void;
-  leaveObjectPattern?: (node: estree.ObjectPattern, parent: estree.Node) => void;
+  enterObjectPattern?:
+      (node: estree.ObjectPattern, parent: estree.Node) => void;
+  leaveObjectPattern?:
+      (node: estree.ObjectPattern, parent: estree.Node) => void;
 
   enterArrayPattern?: (node: estree.ArrayPattern, parent: estree.Node) => void;
   leaveArrayPattern?: (node: estree.ArrayPattern, parent: estree.Node) => void;
@@ -162,48 +242,76 @@ export interface Visitor {
   enterRestElement?: (node: estree.RestElement, parent: estree.Node) => void;
   leaveRestElement?: (node: estree.RestElement, parent: estree.Node) => void;
 
-  enterAssignmentPattern?: (node: estree.AssignmentPattern, parent: estree.Node) => void;
-  leaveAssignmentPattern?: (node: estree.AssignmentPattern, parent: estree.Node) => void;
+  enterAssignmentPattern?:
+      (node: estree.AssignmentPattern, parent: estree.Node) => void;
+  leaveAssignmentPattern?:
+      (node: estree.AssignmentPattern, parent: estree.Node) => void;
 
-  enterMethodDefinition?: (node: estree.MethodDefinition, parent: estree.Node) => void;
-  leaveMethodDefinition?: (node: estree.MethodDefinition, parent: estree.Node) => void;
+  enterMethodDefinition?:
+      (node: estree.MethodDefinition, parent: estree.Node) => void;
+  leaveMethodDefinition?:
+      (node: estree.MethodDefinition, parent: estree.Node) => void;
 
-  enterClassDeclaration?: (node: estree.ClassDeclaration, parent: estree.Node) => void;
-  leaveClassDeclaration?: (node: estree.ClassDeclaration, parent: estree.Node) => void;
+  enterClassDeclaration?:
+      (node: estree.ClassDeclaration, parent: estree.Node) => void;
+  leaveClassDeclaration?:
+      (node: estree.ClassDeclaration, parent: estree.Node) => void;
 
-  enterClassExpression?: (node: estree.ClassExpression, parent: estree.Node) => void;
-  leaveClassExpression?: (node: estree.ClassExpression, parent: estree.Node) => void;
+  enterClassExpression?:
+      (node: estree.ClassExpression, parent: estree.Node) => void;
+  leaveClassExpression?:
+      (node: estree.ClassExpression, parent: estree.Node) => void;
 
   enterMetaProperty?: (node: estree.MetaProperty, parent: estree.Node) => void;
   leaveMetaProperty?: (node: estree.MetaProperty, parent: estree.Node) => void;
 
-  enterModuleDeclaration?: (node: estree.ModuleDeclaration, parent: estree.Node) => void;
-  leaveModuleDeclaration?: (node: estree.ModuleDeclaration, parent: estree.Node) => void;
+  enterModuleDeclaration?:
+      (node: estree.ModuleDeclaration, parent: estree.Node) => void;
+  leaveModuleDeclaration?:
+      (node: estree.ModuleDeclaration, parent: estree.Node) => void;
 
-  enterModuleSpecifier?: (node: estree.ModuleSpecifier, parent: estree.Node) => void;
-  leaveModuleSpecifier?: (node: estree.ModuleSpecifier, parent: estree.Node) => void;
+  enterModuleSpecifier?:
+      (node: estree.ModuleSpecifier, parent: estree.Node) => void;
+  leaveModuleSpecifier?:
+      (node: estree.ModuleSpecifier, parent: estree.Node) => void;
 
-  enterImportDeclaration?: (node: estree.ImportDeclaration, parent: estree.Node) => void;
-  leaveImportDeclaration?: (node: estree.ImportDeclaration, parent: estree.Node) => void;
+  enterImportDeclaration?:
+      (node: estree.ImportDeclaration, parent: estree.Node) => void;
+  leaveImportDeclaration?:
+      (node: estree.ImportDeclaration, parent: estree.Node) => void;
 
-  enterImportSpecifier?: (node: estree.ImportSpecifier, parent: estree.Node) => void;
-  leaveImportSpecifier?: (node: estree.ImportSpecifier, parent: estree.Node) => void;
+  enterImportSpecifier?:
+      (node: estree.ImportSpecifier, parent: estree.Node) => void;
+  leaveImportSpecifier?:
+      (node: estree.ImportSpecifier, parent: estree.Node) => void;
 
-  enterImportDefaultSpecifier?: (node: estree.ImportDefaultSpecifier, parent: estree.Node) => void;
-  leaveImportDefaultSpecifier?: (node: estree.ImportDefaultSpecifier, parent: estree.Node) => void;
+  enterImportDefaultSpecifier?:
+      (node: estree.ImportDefaultSpecifier, parent: estree.Node) => void;
+  leaveImportDefaultSpecifier?:
+      (node: estree.ImportDefaultSpecifier, parent: estree.Node) => void;
 
-  enterImportNamespaceSpecifier?: (node: estree.ImportNamespaceSpecifier, parent: estree.Node) => void;
-  leaveImportNamespaceSpecifier?: (node: estree.ImportNamespaceSpecifier, parent: estree.Node) => void;
+  enterImportNamespaceSpecifier?:
+      (node: estree.ImportNamespaceSpecifier, parent: estree.Node) => void;
+  leaveImportNamespaceSpecifier?:
+      (node: estree.ImportNamespaceSpecifier, parent: estree.Node) => void;
 
-  enterExportNamedDeclaration?: (node: estree.ExportNamedDeclaration, parent: estree.Node) => void;
-  leaveExportNamedDeclaration?: (node: estree.ExportNamedDeclaration, parent: estree.Node) => void;
+  enterExportNamedDeclaration?:
+      (node: estree.ExportNamedDeclaration, parent: estree.Node) => void;
+  leaveExportNamedDeclaration?:
+      (node: estree.ExportNamedDeclaration, parent: estree.Node) => void;
 
-  enterExportSpecifier?: (node: estree.ExportSpecifier, parent: estree.Node) => void;
-  leaveExportSpecifier?: (node: estree.ExportSpecifier, parent: estree.Node) => void;
+  enterExportSpecifier?:
+      (node: estree.ExportSpecifier, parent: estree.Node) => void;
+  leaveExportSpecifier?:
+      (node: estree.ExportSpecifier, parent: estree.Node) => void;
 
-  enterExportDefaultDeclaration?: (node: estree.ExportDefaultDeclaration, parent: estree.Node) => void;
-  leaveExportDefaultDeclaration?: (node: estree.ExportDefaultDeclaration, parent: estree.Node) => void;
+  enterExportDefaultDeclaration?:
+      (node: estree.ExportDefaultDeclaration, parent: estree.Node) => void;
+  leaveExportDefaultDeclaration?:
+      (node: estree.ExportDefaultDeclaration, parent: estree.Node) => void;
 
-  enterExportAllDeclaration?: (node: estree.ExportAllDeclaration, parent: estree.Node) => void;
-  leaveExportAllDeclaration?: (node: estree.ExportAllDeclaration, parent: estree.Node) => void;
+  enterExportAllDeclaration?:
+      (node: estree.ExportAllDeclaration, parent: estree.Node) => void;
+  leaveExportAllDeclaration?:
+      (node: estree.ExportAllDeclaration, parent: estree.Node) => void;
 }

--- a/src/ast-utils/jsdoc.ts
+++ b/src/ast-utils/jsdoc.ts
@@ -1,11 +1,15 @@
 /**
  * @license
  * Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
- * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
- * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
- * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
  * Code distributed by Google as part of the polymer project is also
- * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
  */
 
 'use strict';
@@ -49,7 +53,8 @@ export interface Annotation {
 //   doctrine.Rules['hero'] = ['parseNamePathOptional', 'ensureEnd'];
 
 //   // // @demo [path/to/demo] [Demo title]
-//   doctrine.Rules['demo'] = ['parseNamePathOptional', 'parseDescription', 'ensureEnd'];
+//   doctrine.Rules['demo'] = ['parseNamePathOptional', 'parseDescription',
+//   'ensureEnd'];
 
 //   // // @polymerBehavior [Polymer.BehaviorName]
 //   doctrine.Rules['polymerBehavior'] = ['parseNamePathOptional', 'ensureEnd'];
@@ -69,32 +74,17 @@ function parseDemo(tag: doctrine.Tag): Tag {
 
 // @hero [path]
 function parseHero(tag: doctrine.Tag): Tag {
-  return {
-    tag:  tag.title,
-    type: null,
-    name: tag.description,
-    description: null
-  };
+  return {tag: tag.title, type: null, name: tag.description, description: null};
 }
 
 // @polymerBehavior [name]
 function parsePolymerBehavior(tag: doctrine.Tag): Tag {
-  return {
-    tag:  tag.title,
-    type: null,
-    name: tag.description,
-    description: null
-  };
+  return {tag: tag.title, type: null, name: tag.description, description: null};
 }
 
 // @pseudoElement name
 function parsePseudoElement(tag: doctrine.Tag): Tag {
-  return {
-    tag:  tag.title,
-    type: null,
-    name: tag.description,
-    description: null
-  };
+  return {tag: tag.title, type: null, name: tag.description, description: null};
 }
 
 const CUSTOM_TAGS: {[name: string]: (tag: doctrine.Tag) => Tag} = {
@@ -108,15 +98,13 @@ const CUSTOM_TAGS: {[name: string]: (tag: doctrine.Tag) => Tag} = {
  * Convert doctrine tags to our tag format
  */
 function _tagsToHydroTags(tags: doctrine.Tag[]): Tag[] {
-  if (!tags)
-    return null;
+  if (!tags) return null;
   return tags.map(function(tag): Tag {
     if (tag.title in CUSTOM_TAGS) {
       return CUSTOM_TAGS[tag.title](tag);
-    }
-    else {
+    } else {
       return {
-        tag:  tag.title,
+        tag: tag.title,
         type: tag.type ? doctrine.type.stringify(tag.type) : null,
         name: tag.name,
         description: tag.description,
@@ -129,17 +117,15 @@ function _tagsToHydroTags(tags: doctrine.Tag[]): Tag[] {
  * removes leading *, and any space before it
  */
 function _removeLeadingAsterisks(description: string): string {
-  if ((typeof description) !== 'string')
-    return description;
+  if ((typeof description) !== 'string') return description;
 
-  return description
-    .split('\n')
-    .map(function(line) {
-      // remove leading '\s*' from each line
-      const match = line.match(/^[\s]*\*\s?(.*)$/);
-      return match ? match[1] : line;
-    })
-    .join('\n');
+  return description.split('\n')
+      .map(function(line) {
+        // remove leading '\s*' from each line
+        const match = line.match(/^[\s]*\*\s?(.*)$/);
+        return match ? match[1] : line;
+      })
+      .join('\n');
 }
 
 /**
@@ -151,15 +137,9 @@ function _removeLeadingAsterisks(description: string): string {
  */
 export function parseJsdoc(docs: string): Annotation {
   docs = _removeLeadingAsterisks(docs);
-  const d = doctrine.parse(docs, {
-    unwrap: false,
-    lineNumber: true,
-    preserveWhitespace: true
-  });
-  return {
-    description: d.description,
-    tags: _tagsToHydroTags(d.tags)
-  };
+  const d = doctrine.parse(
+      docs, {unwrap: false, lineNumber: true, preserveWhitespace: true});
+  return {description: d.description, tags: _tagsToHydroTags(d.tags)};
 }
 
 // Utility
@@ -189,7 +169,7 @@ export function getTag(jsdoc: Annotation, tagName: string, key?: string): any {
 
 export function unindent(text: string): string {
   if (!text) return text;
-  const lines  = text.replace(/\t/g, '  ').split('\n');
+  const lines = text.replace(/\t/g, '  ').split('\n');
   const indent = lines.reduce<number>(function(prev, line) {
     if (/^\s*$/.test(line)) return prev;  // Completely ignore blank lines.
 

--- a/src/ast-utils/jsdoc.ts
+++ b/src/ast-utils/jsdoc.ts
@@ -98,7 +98,8 @@ const CUSTOM_TAGS: {[name: string]: (tag: doctrine.Tag) => Tag} = {
  * Convert doctrine tags to our tag format
  */
 function _tagsToHydroTags(tags: doctrine.Tag[]): Tag[] {
-  if (!tags) return null;
+  if (!tags)
+    return null;
   return tags.map(function(tag): Tag {
     if (tag.title in CUSTOM_TAGS) {
       return CUSTOM_TAGS[tag.title](tag);
@@ -117,7 +118,8 @@ function _tagsToHydroTags(tags: doctrine.Tag[]): Tag[] {
  * removes leading *, and any space before it
  */
 function _removeLeadingAsterisks(description: string): string {
-  if ((typeof description) !== 'string') return description;
+  if ((typeof description) !== 'string')
+    return description;
 
   return description.split('\n')
       .map(function(line) {
@@ -145,8 +147,11 @@ export function parseJsdoc(docs: string): Annotation {
 // Utility
 
 export function hasTag(jsdoc: Annotation, tagName: string): boolean {
-  if (!jsdoc || !jsdoc.tags) return false;
-  return jsdoc.tags.some(function(tag) { return tag.tag === tagName; });
+  if (!jsdoc || !jsdoc.tags)
+    return false;
+  return jsdoc.tags.some(function(tag) {
+    return tag.tag === tagName;
+  });
 }
 
 /**
@@ -157,7 +162,8 @@ export function hasTag(jsdoc: Annotation, tagName: string): boolean {
 export function getTag(jsdoc: Annotation, tagName: string): Tag;
 export function getTag(jsdoc: Annotation, tagName: string, key: string): string;
 export function getTag(jsdoc: Annotation, tagName: string, key?: string): any {
-  if (!jsdoc || !jsdoc.tags) return null;
+  if (!jsdoc || !jsdoc.tags)
+    return null;
   for (let i = 0; i < jsdoc.tags.length; i++) {
     const tag = jsdoc.tags[i];
     if (tag.tag === tagName) {
@@ -168,15 +174,22 @@ export function getTag(jsdoc: Annotation, tagName: string, key?: string): any {
 }
 
 export function unindent(text: string): string {
-  if (!text) return text;
+  if (!text)
+    return text;
   const lines = text.replace(/\t/g, '  ').split('\n');
   const indent = lines.reduce<number>(function(prev, line) {
-    if (/^\s*$/.test(line)) return prev;  // Completely ignore blank lines.
+    if (/^\s*$/.test(line))
+      return prev;  // Completely ignore blank lines.
 
     const lineIndent = line.match(/^(\s*)/)[0].length;
-    if (prev === null) return lineIndent;
+    if (prev === null)
+      return lineIndent;
     return lineIndent < prev ? lineIndent : prev;
   }, null);
 
-  return lines.map(function(l) { return l.substr(indent); }).join('\n');
+  return lines
+      .map(function(l) {
+        return l.substr(indent);
+      })
+      .join('\n');
 }

--- a/src/ast/ast.ts
+++ b/src/ast/ast.ts
@@ -1,11 +1,15 @@
 /**
  * @license
  * Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
- * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
- * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
- * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
  * Code distributed by Google as part of the polymer project is also
- * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
  */
 
 export * from './behavior-descriptor';

--- a/src/ast/behavior-descriptor.ts
+++ b/src/ast/behavior-descriptor.ts
@@ -9,4 +9,6 @@ export interface BehaviorDescriptor extends ElementDescriptor {
 
 export type BehaviorOrName = BehaviorDescriptor | string;
 
-export type BehaviorsByName = {[name: string]: BehaviorDescriptor};
+export type BehaviorsByName = {
+  [name: string]: BehaviorDescriptor
+};

--- a/src/ast/descriptor.ts
+++ b/src/ast/descriptor.ts
@@ -1,6 +1,6 @@
 import * as jsdoc from '../ast-utils/jsdoc';
 
-export type LiteralValue = string|number|boolean|RegExp;
+export type LiteralValue = string | number | boolean | RegExp;
 
 export interface Descriptor {
   jsdoc?: jsdoc.Annotation;

--- a/src/ast/document-descriptor.ts
+++ b/src/ast/document-descriptor.ts
@@ -27,5 +27,7 @@ export class DocumentDescriptor {
     this.entities = entities;
   }
 
-  get url() { return this.document.url; }
+  get url() {
+    return this.document.url;
+  }
 }

--- a/src/ast/document-descriptor.ts
+++ b/src/ast/document-descriptor.ts
@@ -1,11 +1,15 @@
 /**
  * @license
  * Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
- * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
- * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
- * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
  * Code distributed by Google as part of the polymer project is also
- * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
  */
 
 import {Document} from '../parser/document';
@@ -23,7 +27,5 @@ export class DocumentDescriptor {
     this.entities = entities;
   }
 
-  get url() {
-    return this.document.url;
-  }
+  get url() { return this.document.url; }
 }

--- a/src/ast/element-descriptor.ts
+++ b/src/ast/element-descriptor.ts
@@ -20,7 +20,7 @@ export interface ElementDescriptor extends Descriptor {
   behaviors?: BehaviorOrName[];
 
   type: string;  // 'element' | 'behavior'
-  demos?: {desc: string; path: string;}[];
+  demos?: {desc: string; path: string}[];
   events?: EventDescriptor[];
   hero?: string;
   domModule?: dom5.Node;

--- a/src/ast/element-descriptor.ts
+++ b/src/ast/element-descriptor.ts
@@ -19,11 +19,8 @@ export interface ElementDescriptor extends Descriptor {
   }[];
   behaviors?: BehaviorOrName[];
 
-  type: string; // 'element' | 'behavior'
-  demos?: {
-    desc: string;
-    path: string;
-  }[];
+  type: string;  // 'element' | 'behavior'
+  demos?: {desc: string; path: string;}[];
   events?: EventDescriptor[];
   hero?: string;
   domModule?: dom5.Node;

--- a/src/ast/element-descriptor.ts
+++ b/src/ast/element-descriptor.ts
@@ -1,10 +1,11 @@
-import * as estree from 'estree';
 import * as dom5 from 'dom5';
+import * as estree from 'estree';
 
 import {BehaviorOrName} from './behavior-descriptor';
 import {Descriptor, LiteralValue} from './descriptor';
 import {EventDescriptor} from './event-descriptor';
 import {PropertyDescriptor} from './property-descriptor';
+
 
 /**
  * The metadata for a single polymer element

--- a/src/ast/event-descriptor.ts
+++ b/src/ast/event-descriptor.ts
@@ -1,5 +1,5 @@
-import {Descriptor} from './descriptor';
 import {BehaviorOrName} from './behavior-descriptor';
+import {Descriptor} from './descriptor';
 
 export interface EventDescriptor extends Descriptor {
   name?: string;

--- a/src/ast/event-descriptor.ts
+++ b/src/ast/event-descriptor.ts
@@ -4,9 +4,5 @@ import {BehaviorOrName} from './behavior-descriptor';
 export interface EventDescriptor extends Descriptor {
   name?: string;
   __fromBehavior?: BehaviorOrName;
-  params?: {
-    type: string,
-    desc: string,
-    name: string
-  }[];
+  params?: {type: string, desc: string, name: string}[];
 }

--- a/src/ast/feature-descriptor.ts
+++ b/src/ast/feature-descriptor.ts
@@ -3,6 +3,4 @@ import {ElementDescriptor} from './element-descriptor';
 /**
  * The metadata for a Polymer feature.
  */
-export interface FeatureDescriptor extends ElementDescriptor {
-
-}
+export interface FeatureDescriptor extends ElementDescriptor {}

--- a/src/ast/function-descriptor.ts
+++ b/src/ast/function-descriptor.ts
@@ -2,5 +2,5 @@ import {PropertyDescriptor} from './property-descriptor';
 
 export interface FunctionDescriptor extends PropertyDescriptor {
   function: boolean;  // true
-  return: {type: string; desc: string;};
+  return: {type: string; desc: string};
 }

--- a/src/ast/function-descriptor.ts
+++ b/src/ast/function-descriptor.ts
@@ -1,9 +1,6 @@
 import {PropertyDescriptor} from './property-descriptor';
 
 export interface FunctionDescriptor extends PropertyDescriptor {
-  function: boolean; // true
-  return: {
-    type: string;
-    desc: string;
-  };
+  function: boolean;  // true
+  return: {type: string; desc: string;};
 }

--- a/src/ast/import-descriptor.ts
+++ b/src/ast/import-descriptor.ts
@@ -13,7 +13,7 @@
  */
 
 export class ImportDescriptor {
-  type: 'html-import' | 'html-script' | 'html-style' | string;
+  type: 'html-import'|'html-script'|'html-style'|string;
 
   /**
    * URL of the import, relative to the document containing the import.

--- a/src/ast/import-descriptor.ts
+++ b/src/ast/import-descriptor.ts
@@ -1,11 +1,15 @@
 /**
  * @license
  * Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
- * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
- * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
- * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
  * Code distributed by Google as part of the polymer project is also
- * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
  */
 
 export class ImportDescriptor {

--- a/src/ast/property-descriptor.ts
+++ b/src/ast/property-descriptor.ts
@@ -16,7 +16,7 @@ export interface PropertyDescriptor extends Descriptor {
   observerNode?: estree.Expression;
   readOnly?: LiteralValue;
   reflectToAttribute?: LiteralValue;
-  default?: LiteralValue;
+  'default'?: LiteralValue;
   private?: boolean;
   configuration?: boolean;
   getter?: boolean;

--- a/src/css/css-document.ts
+++ b/src/css/css-document.ts
@@ -19,7 +19,11 @@ import {Document, Options} from '../parser/document';
 export class CssDocument extends Document<Node, NodeVisitor> {
   type = 'css';
 
-  constructor(from: Options<Node>) { super(from); }
+  constructor(from: Options<Node>) {
+    super(from);
+  }
 
-  visit(visitors: NodeVisitor[]) { throw new Error('Not implemented'); }
+  visit(visitors: NodeVisitor[]) {
+    throw new Error('Not implemented');
+  }
 }

--- a/src/css/css-document.ts
+++ b/src/css/css-document.ts
@@ -1,11 +1,15 @@
 /**
  * @license
  * Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
- * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
- * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
- * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
  * Code distributed by Google as part of the polymer project is also
- * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
  */
 
 import {Node, NodeVisitor} from 'shady-css-parser';
@@ -15,11 +19,7 @@ import {Document, Options} from '../parser/document';
 export class CssDocument extends Document<Node, NodeVisitor> {
   type = 'css';
 
-  constructor(from: Options<Node>) {
-    super(from);
-  }
+  constructor(from: Options<Node>) { super(from); }
 
-  visit(visitors: NodeVisitor[]) {
-    throw new Error('Not implemented');
-  }
+  visit(visitors: NodeVisitor[]) { throw new Error('Not implemented'); }
 }

--- a/src/css/css-parser.ts
+++ b/src/css/css-parser.ts
@@ -1,11 +1,15 @@
 /**
  * @license
  * Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
- * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
- * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
- * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
  * Code distributed by Google as part of the polymer project is also
- * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
  */
 
 import * as shadyCss from 'shady-css-parser';
@@ -16,7 +20,6 @@ import {Parser} from '../parser/parser';
 import {CssDocument} from './css-document';
 
 export class CssParser implements Parser<CssDocument> {
-
   analyzer: Analyzer;
   private _parser: shadyCss.Parser;
 
@@ -28,11 +31,9 @@ export class CssParser implements Parser<CssDocument> {
   parse(contents: string, url: string): CssDocument {
     let ast = this._parser.parse(contents);
 
-    return new CssDocument({
-      url,
-      contents,
-      ast,
-    });
+    return new CssDocument(
+        {
+            url, contents, ast,
+        });
   }
-
 }

--- a/src/css/css-parser.ts
+++ b/src/css/css-parser.ts
@@ -31,9 +31,8 @@ export class CssParser implements Parser<CssDocument> {
   parse(contents: string, url: string): CssDocument {
     let ast = this._parser.parse(contents);
 
-    return new CssDocument(
-        {
-            url, contents, ast,
-        });
+    return new CssDocument({
+        url, contents, ast,
+    });
   }
 }

--- a/src/entity/entity-finder.ts
+++ b/src/entity/entity-finder.ts
@@ -1,11 +1,15 @@
 /**
  * @license
  * Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
- * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
- * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
- * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
  * Code distributed by Google as part of the polymer project is also
- * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
  */
 
 import {Analyzer} from '../analyzer';
@@ -13,9 +17,10 @@ import {Descriptor} from '../ast/ast';
 import {Document} from '../parser/document';
 
 export interface EntityFinder<D extends Document<A, V>, A, V> {
-  findEntities<D>(document: D, visit: (visitor: V) => Promise<void>): Promise<Descriptor[]>;
+  findEntities<D>(document: D, visit: (visitor: V) => Promise<void>):
+      Promise<Descriptor[]>;
 }
 
 export interface EntityFinderConstructor {
-  new(analyzer: Analyzer): EntityFinder<any, any, any>;
+  new (analyzer: Analyzer): EntityFinder<any, any, any>;
 }

--- a/src/entity/find-entities.ts
+++ b/src/entity/find-entities.ts
@@ -12,14 +12,14 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {Document} from '../parser/document';
 import {Descriptor} from '../ast/ast';
+import {Document} from '../parser/document';
+
 import {EntityFinder} from './entity-finder';
 
 export async function findEntities(
     document: Document<any, any>,
     finders: EntityFinder<any, any, any>[]): Promise<Descriptor[]> {
-
   // Finders register a visitor to run via the `visit` callback passed to
   // `findEntities()`. We run these visitors in a batch, then pass control back
   // to the `findEntities` methods by resolving a single Promise return for
@@ -30,19 +30,15 @@ export async function findEntities(
   let batchDone: () => void;
 
   // Promise returned by visit()
-  let
-  visitorsPromise: Promise<void>;
+  let visitorsPromise: Promise<void>;
 
   // Current batch of visitors
-  let
-  visitors: any[];
+  let visitors: any[];
 
   // A Promise that runs the next batch of visitors in a microtask
-  let
-  runner: Promise<void>;
+  let runner: Promise<void>;
 
-  let
-  visitError: any;
+  let visitError: any;
 
   // Initializes the current batch running state
   function setup() {
@@ -89,7 +85,8 @@ export async function findEntities(
   const nestedEntities = await Promise.all(finderPromises);
 
   // TODO(justinfagnani): write a test w/ a visitor that throws to test this
-  if (visitError) throw visitError;
+  if (visitError)
+    throw visitError;
 
   // Flatten the nested list
   return Array.prototype.concat.apply([], nestedEntities);

--- a/src/entity/find-entities.ts
+++ b/src/entity/find-entities.ts
@@ -1,11 +1,15 @@
 /**
  * @license
  * Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
- * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
- * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
- * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
  * Code distributed by Google as part of the polymer project is also
- * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
  */
 
 import {Document} from '../parser/document';
@@ -26,21 +30,24 @@ export async function findEntities(
   let batchDone: () => void;
 
   // Promise returned by visit()
-  let visitorsPromise: Promise<void>;
+  let
+  visitorsPromise: Promise<void>;
 
   // Current batch of visitors
-  let visitors: any[];
+  let
+  visitors: any[];
 
   // A Promise that runs the next batch of visitors in a microtask
-  let runner: Promise<void>;
+  let
+  runner: Promise<void>;
 
-  let visitError: any;
+  let
+  visitError: any;
 
   // Initializes the current batch running state
   function setup() {
-    visitorsPromise = new Promise<void>((resolve, _) => {
-      batchDone = resolve;
-    });
+    visitorsPromise =
+        new Promise<void>((resolve, _) => { batchDone = resolve; });
     visitors = [];
     runner = null;
   }
@@ -81,9 +88,7 @@ export async function findEntities(
   const nestedEntities = await Promise.all(finderPromises);
 
   // TODO(justinfagnani): write a test w/ a visitor that throws to test this
-  if (visitError) {
-    throw visitError;
-  }
+  if (visitError) { throw visitError;}
 
   // Flatten the nested list
   return Array.prototype.concat.apply([], nestedEntities);

--- a/src/entity/find-entities.ts
+++ b/src/entity/find-entities.ts
@@ -88,7 +88,7 @@ export async function findEntities(
   const nestedEntities = await Promise.all(finderPromises);
 
   // TODO(justinfagnani): write a test w/ a visitor that throws to test this
-  if (visitError) { throw visitError;}
+  if (visitError) throw visitError;
 
   // Flatten the nested list
   return Array.prototype.concat.apply([], nestedEntities);

--- a/src/entity/find-entities.ts
+++ b/src/entity/find-entities.ts
@@ -46,8 +46,9 @@ export async function findEntities(
 
   // Initializes the current batch running state
   function setup() {
-    visitorsPromise =
-        new Promise<void>((resolve, _) => { batchDone = resolve; });
+    visitorsPromise = new Promise<void>((resolve, _) => {
+      batchDone = resolve;
+    });
     visitors = [];
     runner = null;
   }

--- a/src/html/html-document.ts
+++ b/src/html/html-document.ts
@@ -26,7 +26,9 @@ export interface HtmlVisitor { (node: ASTNode): void; }
 export class HtmlDocument extends Document<ASTNode, HtmlVisitor> {
   type = 'html';
 
-  constructor(from: Options<ASTNode>) { super(from); }
+  constructor(from: Options<ASTNode>) {
+    super(from);
+  }
 
   visit(visitors: HtmlVisitor[]) {
     dom5.nodeWalk(this.ast, (node) => {

--- a/src/html/html-document.ts
+++ b/src/html/html-document.ts
@@ -1,11 +1,15 @@
 /**
  * @license
  * Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
- * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
- * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
- * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
  * Code distributed by Google as part of the polymer project is also
- * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
  */
 
 import * as dom5 from 'dom5';
@@ -17,16 +21,12 @@ import {Document, Options} from '../parser/document';
  * The ASTs of the HTML elements needed to represent Polymer elements.
  */
 
-export interface HtmlVisitor {
-  (node: ASTNode): void;
-}
+export interface HtmlVisitor { (node: ASTNode): void; }
 
 export class HtmlDocument extends Document<ASTNode, HtmlVisitor> {
   type = 'html';
 
-  constructor(from: Options<ASTNode>) {
-    super(from);
-  }
+  constructor(from: Options<ASTNode>) { super(from); }
 
   visit(visitors: HtmlVisitor[]) {
     dom5.nodeWalk(this.ast, (node) => {

--- a/src/html/html-entity-finder.ts
+++ b/src/html/html-entity-finder.ts
@@ -13,9 +13,11 @@
  */
 
 import {ASTNode} from 'parse5';
+
 import {Descriptor} from '../ast/ast';
-import {HtmlDocument, HtmlVisitor} from './html-document';
 import {EntityFinder} from '../entity/entity-finder';
+
+import {HtmlDocument, HtmlVisitor} from './html-document';
 
 export interface HtmlEntityFinder extends
     EntityFinder<HtmlDocument, ASTNode, HtmlVisitor> {}

--- a/src/html/html-entity-finder.ts
+++ b/src/html/html-entity-finder.ts
@@ -1,11 +1,15 @@
 /**
  * @license
  * Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
- * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
- * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
- * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
  * Code distributed by Google as part of the polymer project is also
- * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
  */
 
 import {ASTNode} from 'parse5';
@@ -13,5 +17,5 @@ import {Descriptor} from '../ast/ast';
 import {HtmlDocument, HtmlVisitor} from './html-document';
 import {EntityFinder} from '../entity/entity-finder';
 
-export interface HtmlEntityFinder
-    extends EntityFinder<HtmlDocument, ASTNode, HtmlVisitor> {}
+export interface HtmlEntityFinder extends
+    EntityFinder<HtmlDocument, ASTNode, HtmlVisitor> {}

--- a/src/html/html-import-finder.ts
+++ b/src/html/html-import-finder.ts
@@ -16,8 +16,9 @@ import * as dom5 from 'dom5';
 import {resolve as resolveUrl} from 'url';
 
 import {ImportDescriptor} from '../ast/ast';
-import {HtmlEntityFinder} from './html-entity-finder';
+
 import {HtmlDocument, HtmlVisitor} from './html-document';
+import {HtmlEntityFinder} from './html-entity-finder';
 
 const p = dom5.predicates;
 

--- a/src/html/html-import-finder.ts
+++ b/src/html/html-import-finder.ts
@@ -1,11 +1,15 @@
 /**
  * @license
  * Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
- * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
- * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
- * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
  * Code distributed by Google as part of the polymer project is also
- * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
  */
 
 import * as dom5 from 'dom5';
@@ -17,23 +21,15 @@ import {HtmlDocument, HtmlVisitor} from './html-document';
 
 const p = dom5.predicates;
 
-const isHtmlImportNode = p.AND(
-  p.hasTagName('link'),
-  (node) => {
-    let rel = dom5.getAttribute(node, 'rel') || '';
-    return rel.split(' ').indexOf('import') !== -1;
-  },
-  p.NOT(
-    p.hasAttrValue('type', 'css')
-  )
-);
+const isHtmlImportNode = p.AND(p.hasTagName('link'), (node) => {
+  let rel = dom5.getAttribute(node, 'rel') || '';
+  return rel.split(' ').indexOf('import') !== -1;
+}, p.NOT(p.hasAttrValue('type', 'css')));
 
 export class HtmlImportFinder implements HtmlEntityFinder {
-
   async findEntities(
-      document: HtmlDocument,
-      visit: (visitor: HtmlVisitor) => Promise<void>
-      ): Promise<ImportDescriptor[]> {
+      document: HtmlDocument, visit: (visitor: HtmlVisitor) => Promise<void>):
+      Promise<ImportDescriptor[]> {
     let imports: ImportDescriptor[] = [];
     await visit((node) => {
       if (isHtmlImportNode(node)) {
@@ -44,5 +40,4 @@ export class HtmlImportFinder implements HtmlEntityFinder {
     });
     return imports;
   }
-
 }

--- a/src/html/html-parser.ts
+++ b/src/html/html-parser.ts
@@ -23,7 +23,9 @@ import {Parser} from '../parser/parser';
 export class HtmlParser implements Parser<HtmlDocument> {
   analyzer: Analyzer;
 
-  constructor(analyzer: Analyzer) { this.analyzer = analyzer; }
+  constructor(analyzer: Analyzer) {
+    this.analyzer = analyzer;
+  }
 
   /**
   * Parse html into ASTs.

--- a/src/html/html-parser.ts
+++ b/src/html/html-parser.ts
@@ -1,11 +1,15 @@
 /**
  * @license
  * Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
- * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
- * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
- * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
  * Code distributed by Google as part of the polymer project is also
- * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
  */
 
 import {ASTNode, parse as parseHtml} from 'parse5';
@@ -17,12 +21,9 @@ import {Document} from '../parser/document';
 import {Parser} from '../parser/parser';
 
 export class HtmlParser implements Parser<HtmlDocument> {
-
   analyzer: Analyzer;
 
-  constructor(analyzer: Analyzer) {
-    this.analyzer = analyzer;
-  }
+  constructor(analyzer: Analyzer) { this.analyzer = analyzer; }
 
   /**
   * Parse html into ASTs.
@@ -32,11 +33,9 @@ export class HtmlParser implements Parser<HtmlDocument> {
   */
   parse(contents: string, url: string): HtmlDocument {
     let ast = parseHtml(contents, {locationInfo: true});
-    return new HtmlDocument({
-      url,
-      contents,
-      ast,
-    });
+    return new HtmlDocument(
+        {
+            url, contents, ast,
+        });
   }
-
 }

--- a/src/html/html-parser.ts
+++ b/src/html/html-parser.ts
@@ -14,11 +14,12 @@
 
 import {ASTNode, parse as parseHtml} from 'parse5';
 
-import {HtmlDocument} from './html-document';
 import {Analyzer} from '../analyzer';
 import {ImportDescriptor} from '../ast/ast';
 import {Document} from '../parser/document';
 import {Parser} from '../parser/parser';
+
+import {HtmlDocument} from './html-document';
 
 export class HtmlParser implements Parser<HtmlDocument> {
   analyzer: Analyzer;
@@ -35,9 +36,8 @@ export class HtmlParser implements Parser<HtmlDocument> {
   */
   parse(contents: string, url: string): HtmlDocument {
     let ast = parseHtml(contents, {locationInfo: true});
-    return new HtmlDocument(
-        {
-            url, contents, ast,
-        });
+    return new HtmlDocument({
+        url, contents, ast,
+    });
   }
 }

--- a/src/html/html-script-finder.ts
+++ b/src/html/html-script-finder.ts
@@ -33,7 +33,9 @@ const isJsScriptNode = p.AND(
 export class HtmlScriptFinder implements HtmlEntityFinder {
   analyzer: Analyzer;
 
-  constructor(analyzer: Analyzer) { this.analyzer = analyzer; }
+  constructor(analyzer: Analyzer) {
+    this.analyzer = analyzer;
+  }
 
   async findEntities(
       document: HtmlDocument,

--- a/src/html/html-script-finder.ts
+++ b/src/html/html-script-finder.ts
@@ -1,11 +1,15 @@
 /**
  * @license
  * Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
- * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
- * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
- * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
  * Code distributed by Google as part of the polymer project is also
- * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
  */
 
 import * as dom5 from 'dom5';
@@ -20,22 +24,16 @@ import {HtmlEntityFinder} from './html-entity-finder';
 const p = dom5.predicates;
 
 const isJsScriptNode = p.AND(
-  p.hasTagName('script'),
-  p.OR(
-    p.NOT(p.hasAttr('type')),
-    p.hasAttrValue('type', 'text/javascript'),
-    p.hasAttrValue('type', 'application/javascript'),
-    p.hasAttrValue('type', 'module')
-  )
-);
+    p.hasTagName('script'),
+    p.OR(
+        p.NOT(p.hasAttr('type')), p.hasAttrValue('type', 'text/javascript'),
+        p.hasAttrValue('type', 'application/javascript'),
+        p.hasAttrValue('type', 'module')));
 
 export class HtmlScriptFinder implements HtmlEntityFinder {
-
   analyzer: Analyzer;
 
-  constructor(analyzer: Analyzer) {
-    this.analyzer = analyzer;
-  }
+  constructor(analyzer: Analyzer) { this.analyzer = analyzer; }
 
   async findEntities(
       document: HtmlDocument,
@@ -58,5 +56,4 @@ export class HtmlScriptFinder implements HtmlEntityFinder {
     let entities = await Promise.all(promises);
     return entities;
   }
-
 }

--- a/src/html/html-script-finder.ts
+++ b/src/html/html-script-finder.ts
@@ -40,7 +40,7 @@ export class HtmlScriptFinder implements HtmlEntityFinder {
   async findEntities(
       document: HtmlDocument,
       visit: (visitor: HtmlVisitor) => Promise<void>): Promise<Descriptor[]> {
-    let promises: Promise<ImportDescriptor | DocumentDescriptor>[] = [];
+    let promises: Promise<ImportDescriptor|DocumentDescriptor>[] = [];
     await visit((node) => {
       if (isJsScriptNode(node)) {
         let src = dom5.getAttribute(node, 'src');

--- a/src/html/html-style-finder.ts
+++ b/src/html/html-style-finder.ts
@@ -1,11 +1,15 @@
 /**
  * @license
  * Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
- * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
- * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
- * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
  * Code distributed by Google as part of the polymer project is also
- * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
  */
 
 import * as dom5 from 'dom5';
@@ -20,36 +24,26 @@ import {HtmlDocument, HtmlVisitor} from './html-document';
 const p = dom5.predicates;
 
 const isStyleElement = p.AND(
-  p.hasTagName('style'),
-  p.OR(
-    p.NOT(p.hasAttr('type')),
-    p.hasAttrValue('type', 'text/css')
-  )
-);
+    p.hasTagName('style'),
+    p.OR(p.NOT(p.hasAttr('type')), p.hasAttrValue('type', 'text/css')));
 
-const isStyleLink = p.AND(
-  p.hasTagName('link'),
-  (node) => {
-    let rel = dom5.getAttribute(node, 'rel') || '';
-    return rel.split(' ').indexOf('stylesheet') !== -1;
-  }
-);
+const isStyleLink = p.AND(p.hasTagName('link'), (node) => {
+  let rel = dom5.getAttribute(node, 'rel') || '';
+  return rel.split(' ').indexOf('stylesheet') !== -1;
+});
 
 const isStyleNode = p.OR(isStyleElement, isStyleLink);
 
 export class HtmlStyleFinder implements HtmlEntityFinder {
-
   analyzer: Analyzer;
 
-  constructor(analyzer: Analyzer) {
-    this.analyzer = analyzer;
-  }
+  constructor(analyzer: Analyzer) { this.analyzer = analyzer; }
 
   async findEntities(
       document: HtmlDocument,
       visit: (visitor: HtmlVisitor) => Promise<void>): Promise<Descriptor[]> {
     let promises: Promise<ImportDescriptor | DocumentDescriptor>[] = [];
-    await visit(async (node) => {
+    await visit(async(node) => {
       if (isStyleNode(node)) {
         let tagName = node.nodeName;
         if (tagName === 'link') {
@@ -67,5 +61,4 @@ export class HtmlStyleFinder implements HtmlEntityFinder {
     let entities = await Promise.all(promises);
     return entities;
   }
-
 }

--- a/src/html/html-style-finder.ts
+++ b/src/html/html-style-finder.ts
@@ -37,7 +37,9 @@ const isStyleNode = p.OR(isStyleElement, isStyleLink);
 export class HtmlStyleFinder implements HtmlEntityFinder {
   analyzer: Analyzer;
 
-  constructor(analyzer: Analyzer) { this.analyzer = analyzer; }
+  constructor(analyzer: Analyzer) {
+    this.analyzer = analyzer;
+  }
 
   async findEntities(
       document: HtmlDocument,

--- a/src/html/html-style-finder.ts
+++ b/src/html/html-style-finder.ts
@@ -18,8 +18,9 @@ import {resolve as resolveUrl} from 'url';
 
 import {Analyzer} from '../analyzer';
 import {Descriptor, DocumentDescriptor, ImportDescriptor} from '../ast/ast';
-import {HtmlEntityFinder} from './html-entity-finder';
+
 import {HtmlDocument, HtmlVisitor} from './html-document';
+import {HtmlEntityFinder} from './html-entity-finder';
 
 const p = dom5.predicates;
 
@@ -44,7 +45,7 @@ export class HtmlStyleFinder implements HtmlEntityFinder {
   async findEntities(
       document: HtmlDocument,
       visit: (visitor: HtmlVisitor) => Promise<void>): Promise<Descriptor[]> {
-    let promises: Promise<ImportDescriptor | DocumentDescriptor>[] = [];
+    let promises: Promise<ImportDescriptor|DocumentDescriptor>[] = [];
     await visit(async(node) => {
       if (isStyleNode(node)) {
         let tagName = node.nodeName;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,15 @@
 /**
  * @license
  * Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
- * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
- * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
- * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
  * Code distributed by Google as part of the polymer project is also
- * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
  */
 
 /// <reference path="../custom_typings/main.d.ts" />

--- a/src/javascript/javascript-document.ts
+++ b/src/javascript/javascript-document.ts
@@ -13,11 +13,12 @@
  */
 
 import {traverse} from 'estraverse';
-import {Program, Node} from 'estree';
+import {Node, Program} from 'estree';
 
 import {Visitor} from '../ast-utils/fluent-traverse';
-export {Visitor} from '../ast-utils/fluent-traverse';
 import {Document, Options} from '../parser/document';
+
+export {Visitor} from '../ast-utils/fluent-traverse';
 
 export class JavaScriptDocument extends Document<Program, Visitor> {
   type = 'js';

--- a/src/javascript/javascript-document.ts
+++ b/src/javascript/javascript-document.ts
@@ -1,11 +1,15 @@
 /**
  * @license
  * Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
- * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
- * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
- * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
  * Code distributed by Google as part of the polymer project is also
- * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
  */
 
 import {traverse} from 'estraverse';
@@ -18,12 +22,9 @@ import {Document, Options} from '../parser/document';
 export class JavaScriptDocument extends Document<Program, Visitor> {
   type = 'js';
 
-  constructor(from: Options<Program>) {
-    super(from);
-  }
+  constructor(from: Options<Program>) { super(from); }
 
   visit(visitors: Visitor[]) {
-
     /**
      * Applies all visiting callbacks from `visitors`.
      */

--- a/src/javascript/javascript-document.ts
+++ b/src/javascript/javascript-document.ts
@@ -22,7 +22,9 @@ import {Document, Options} from '../parser/document';
 export class JavaScriptDocument extends Document<Program, Visitor> {
   type = 'js';
 
-  constructor(from: Options<Program>) { super(from); }
+  constructor(from: Options<Program>) {
+    super(from);
+  }
 
   visit(visitors: Visitor[]) {
     /**

--- a/src/javascript/javascript-element-finder.ts
+++ b/src/javascript/javascript-element-finder.ts
@@ -1,11 +1,15 @@
 /**
  * @license
  * Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
- * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
- * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
- * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
  * Code distributed by Google as part of the polymer project is also
- * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
  */
 
 import * as estraverse from 'estraverse';
@@ -19,19 +23,18 @@ import * as analyzeProperties from '../ast-utils/analyze-properties';
 import * as astValue from '../ast-utils/ast-value';
 import {
   declarationPropertyHandlers,
-  PropertyHandlers} from '../ast-utils/declaration-property-handlers';
+  PropertyHandlers
+} from '../ast-utils/declaration-property-handlers';
 import * as docs from '../ast-utils/docs';
 import * as esutil from '../ast-utils/esutil';
 import {Visitor} from '../ast-utils/fluent-traverse';
 
 export class ElementFinder implements JavaScriptEntityFinder {
-
   constructor(analyzer: Analyzer) {}
 
   async findEntities(
-      document: JavaScriptDocument,
-      visit: (visitor: Visitor) => Promise<void>
-      ): Promise<ElementDescriptor[]> {
+      document: JavaScriptDocument, visit: (visitor: Visitor) => Promise<void>):
+      Promise<ElementDescriptor[]> {
     let visitor = new ElementVisitor();
     await visit(visitor);
     return visitor.entities;
@@ -54,7 +57,7 @@ class ElementVisitor implements Visitor {
       type: 'element',
       desc: esutil.getAttachedComment(node),
       events: esutil.getEventComments(node).map(function(event) {
-        return { desc: event };
+        return {desc: event};
       }),
       properties: [],
       behaviors: [],
@@ -73,7 +76,8 @@ class ElementVisitor implements Visitor {
     this.classDetected = false;
   }
 
-  enterAssignmentExpression(node: estree.AssignmentExpression, parent: estree.Node) {
+  enterAssignmentExpression(
+      node: estree.AssignmentExpression, parent: estree.Node) {
     if (!this.element) {
       return;
     }
@@ -104,8 +108,10 @@ class ElementVisitor implements Visitor {
       computed: false,
       type: 'Property'
     };
-    const propDesc = <PropertyDescriptor>docs.annotate(esutil.toPropertyDescriptor(prop));
-    if (prop && prop.kind === 'get' && (propDesc.name === 'behaviors' || propDesc.name === 'observers')) {
+    const propDesc =
+        <PropertyDescriptor>docs.annotate(esutil.toPropertyDescriptor(prop));
+    if (prop && prop.kind === 'get' &&
+        (propDesc.name === 'behaviors' || propDesc.name === 'observers')) {
       let returnStatement = <estree.ReturnStatement>node.value.body.body[0];
       let argument = <estree.ArrayExpression>returnStatement.argument;
       if (propDesc.name === 'behaviors') {
@@ -114,7 +120,8 @@ class ElementVisitor implements Visitor {
         });
       } else {
         argument.elements.forEach((elementObject: estree.Literal) => {
-          this.element.observers.push({ javascriptNode: elementObject, expression: elementObject.raw });
+          this.element.observers.push(
+              {javascriptNode: elementObject, expression: elementObject.raw});
         });
       }
     } else {
@@ -123,7 +130,8 @@ class ElementVisitor implements Visitor {
   }
 
   enterCallExpression(node: estree.CallExpression, parent: estree.Node) {
-    // When dealing with a class, enterCallExpression is called after the parsing actually starts
+    // When dealing with a class, enterCallExpression is called after the
+    // parsing actually starts
     if (this.classDetected) {
       return estraverse.VisitorOption.Skip;
     }
@@ -134,7 +142,7 @@ class ElementVisitor implements Visitor {
         this.element = {
           type: 'element',
           desc: esutil.getAttachedComment(parent),
-          events: esutil.getEventComments(parent).map( function(event) {
+          events: esutil.getEventComments(parent).map(function(event) {
             return {desc: event};
           })
         };
@@ -146,7 +154,8 @@ class ElementVisitor implements Visitor {
   leaveCallExpression(node: estree.CallExpression, parent: estree.Node) {
     let callee = node.callee;
     let args = node.arguments;
-    if (callee.type === 'Identifier' && args.length === 1 && args[0].type === 'ObjectExpression') {
+    if (callee.type === 'Identifier' && args.length === 1 &&
+        args[0].type === 'ObjectExpression') {
       if (callee.name === 'Polymer') {
         if (this.element) {
           this.entities.push(this.element);
@@ -158,7 +167,8 @@ class ElementVisitor implements Visitor {
   }
 
   enterObjectExpression(node: estree.ObjectExpression, parent: estree.Node) {
-    // When dealing with a class, there is no single object that we can parse to retrieve all properties
+    // When dealing with a class, there is no single object that we can parse to
+    // retrieve all properties
     if (this.classDetected) {
       return estraverse.VisitorOption.Skip;
     }

--- a/src/javascript/javascript-element-finder.ts
+++ b/src/javascript/javascript-element-finder.ts
@@ -15,19 +15,17 @@
 import * as estraverse from 'estraverse';
 import * as estree from 'estree';
 
-import {JavaScriptDocument} from './javascript-document';
-import {JavaScriptEntityFinder} from './javascript-entity-finder';
 import {Analyzer} from '../analyzer';
-import {Descriptor, ElementDescriptor, PropertyDescriptor} from '../ast/ast';
 import * as analyzeProperties from '../ast-utils/analyze-properties';
 import * as astValue from '../ast-utils/ast-value';
-import {
-  declarationPropertyHandlers,
-  PropertyHandlers
-} from '../ast-utils/declaration-property-handlers';
+import {PropertyHandlers, declarationPropertyHandlers} from '../ast-utils/declaration-property-handlers';
 import * as docs from '../ast-utils/docs';
 import * as esutil from '../ast-utils/esutil';
 import {Visitor} from '../ast-utils/fluent-traverse';
+import {Descriptor, ElementDescriptor, PropertyDescriptor} from '../ast/ast';
+
+import {JavaScriptDocument} from './javascript-document';
+import {JavaScriptEntityFinder} from './javascript-entity-finder';
 
 export class ElementFinder implements JavaScriptEntityFinder {
   constructor(analyzer: Analyzer) {

--- a/src/javascript/javascript-element-finder.ts
+++ b/src/javascript/javascript-element-finder.ts
@@ -30,7 +30,8 @@ import * as esutil from '../ast-utils/esutil';
 import {Visitor} from '../ast-utils/fluent-traverse';
 
 export class ElementFinder implements JavaScriptEntityFinder {
-  constructor(analyzer: Analyzer) {}
+  constructor(analyzer: Analyzer) {
+  }
 
   async findEntities(
       document: JavaScriptDocument, visit: (visitor: Visitor) => Promise<void>):

--- a/src/javascript/javascript-entity-finder.ts
+++ b/src/javascript/javascript-entity-finder.ts
@@ -14,11 +14,11 @@
 
 import {Program} from 'estree';
 
-import {JavaScriptDocument} from './javascript-document';
-import {Descriptor} from '../ast/ast';
 import {Visitor} from '../ast-utils/fluent-traverse';
+import {Descriptor} from '../ast/ast';
 import {EntityFinder} from '../entity/entity-finder';
 
+import {JavaScriptDocument} from './javascript-document';
+
 export interface JavaScriptEntityFinder extends
-    EntityFinder<JavaScriptDocument, Program, Visitor>,
-    Visitor {}
+    EntityFinder<JavaScriptDocument, Program, Visitor>, Visitor {}

--- a/src/javascript/javascript-entity-finder.ts
+++ b/src/javascript/javascript-entity-finder.ts
@@ -1,11 +1,15 @@
 /**
  * @license
  * Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
- * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
- * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
- * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
  * Code distributed by Google as part of the polymer project is also
- * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
  */
 
 import {Program} from 'estree';
@@ -16,4 +20,5 @@ import {Visitor} from '../ast-utils/fluent-traverse';
 import {EntityFinder} from '../entity/entity-finder';
 
 export interface JavaScriptEntityFinder extends
-    EntityFinder<JavaScriptDocument, Program, Visitor>, Visitor {}
+    EntityFinder<JavaScriptDocument, Program, Visitor>,
+    Visitor {}

--- a/src/javascript/javascript-parser.ts
+++ b/src/javascript/javascript-parser.ts
@@ -13,13 +13,14 @@
  */
 
 import * as acorn from 'acorn';
-import {Program} from 'estree';
 import * as estraverse from 'estraverse';
+import {Program} from 'estree';
 
 import {Analyzer} from '../analyzer';
-import {Parser} from '../parser/parser';
-import {JavaScriptDocument} from './javascript-document';
 import {Visitor} from '../ast-utils/fluent-traverse';
+import {Parser} from '../parser/parser';
+
+import {JavaScriptDocument} from './javascript-document';
 
 export class JavaScriptParser implements Parser<JavaScriptDocument> {
   analyzer: Analyzer;

--- a/src/javascript/javascript-parser.ts
+++ b/src/javascript/javascript-parser.ts
@@ -24,7 +24,9 @@ import {Visitor} from '../ast-utils/fluent-traverse';
 export class JavaScriptParser implements Parser<JavaScriptDocument> {
   analyzer: Analyzer;
 
-  constructor(analyzer: Analyzer) { this.analyzer = analyzer; }
+  constructor(analyzer: Analyzer) {
+    this.analyzer = analyzer;
+  }
 
   parse(contents: string, url: string): JavaScriptDocument {
     // TODO(justinfagnani): add onComment handler

--- a/src/javascript/javascript-parser.ts
+++ b/src/javascript/javascript-parser.ts
@@ -1,11 +1,15 @@
 /**
  * @license
  * Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
- * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
- * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
- * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
  * Code distributed by Google as part of the polymer project is also
- * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
  */
 
 import * as acorn from 'acorn';
@@ -18,12 +22,9 @@ import {JavaScriptDocument} from './javascript-document';
 import {Visitor} from '../ast-utils/fluent-traverse';
 
 export class JavaScriptParser implements Parser<JavaScriptDocument> {
-
   analyzer: Analyzer;
 
-  constructor(analyzer: Analyzer) {
-    this.analyzer = analyzer;
-  }
+  constructor(analyzer: Analyzer) { this.analyzer = analyzer; }
 
   parse(contents: string, url: string): JavaScriptDocument {
     // TODO(justinfagnani): add onComment handler
@@ -33,11 +34,6 @@ export class JavaScriptParser implements Parser<JavaScriptDocument> {
       locations: true,
     });
 
-    return new JavaScriptDocument({
-      url,
-      contents,
-      ast,
-    });
+    return new JavaScriptDocument({url, contents, ast});
   }
-
 }

--- a/src/parser/document.ts
+++ b/src/parser/document.ts
@@ -1,11 +1,15 @@
 /**
  * @license
  * Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
- * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
- * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
- * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
  * Code distributed by Google as part of the polymer project is also
- * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
  */
 
 import {Analyzer} from '../analyzer';
@@ -17,7 +21,6 @@ import {Analyzer} from '../analyzer';
  * @template V The Visitor type of the document
  */
 export abstract class Document<A, V> {
-
   // abstract type: string; // argh, how do I declare an abstract field?
   type: string;
   url: string;
@@ -31,7 +34,6 @@ export abstract class Document<A, V> {
   }
 
   abstract visit(visitors: V[]): void;
-
 }
 
 export interface Options<A> {

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -1,11 +1,15 @@
 /**
  * @license
  * Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
- * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
- * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
- * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
  * Code distributed by Google as part of the polymer project is also
- * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
  */
 
 import {Document} from './document';

--- a/src/url-loader/fetch-url-loader.ts
+++ b/src/url-loader/fetch-url-loader.ts
@@ -1,11 +1,15 @@
 /**
  * @license
  * Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
- * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
- * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
- * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
  * Code distributed by Google as part of the polymer project is also
- * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
  */
 
 import {resolve as resolveUrl} from 'url';
@@ -17,31 +21,25 @@ import {UrlLoader} from './url-loader';
 export class FetchUrlLoader implements UrlLoader {
   baseUrl: string;
 
-  constructor(baseUrl: string) {
-    this.baseUrl = baseUrl;
-  }
+  constructor(baseUrl: string) { this.baseUrl = baseUrl; }
 
   _resolve(url: string) {
     return this.baseUrl ? resolveUrl(this.baseUrl, url) : url;
   }
 
-  canLoad(url: string): boolean {
-    return true;
-  }
+  canLoad(url: string): boolean { return true; }
 
   load(url: string): Promise<string> {
     // Use []'s to shut TS up for now, until this file can have use a
     // different core lib
-    return window['fetch'](this._resolve(url))
-      .then((response: any) => {
-        if (response.ok) {
-          return response.text();
-        } else {
-          return response.text().then((content: string) => {
-            throw new Error(`Response not ok: ${content}`);
-          });
-        }
-      });
+    return window['fetch'](this._resolve(url)).then((response: any) => {
+      if (response.ok) {
+        return response.text();
+      } else {
+        return response.text().then((content: string) => {
+          throw new Error(`Response not ok: ${content}`);
+        });
+      }
+    });
   }
-
 }

--- a/src/url-loader/fetch-url-loader.ts
+++ b/src/url-loader/fetch-url-loader.ts
@@ -21,13 +21,17 @@ import {UrlLoader} from './url-loader';
 export class FetchUrlLoader implements UrlLoader {
   baseUrl: string;
 
-  constructor(baseUrl: string) { this.baseUrl = baseUrl; }
+  constructor(baseUrl: string) {
+    this.baseUrl = baseUrl;
+  }
 
   _resolve(url: string) {
     return this.baseUrl ? resolveUrl(this.baseUrl, url) : url;
   }
 
-  canLoad(url: string): boolean { return true; }
+  canLoad(url: string): boolean {
+    return true;
+  }
 
   load(url: string): Promise<string> {
     // Use []'s to shut TS up for now, until this file can have use a

--- a/src/url-loader/fs-url-loader.ts
+++ b/src/url-loader/fs-url-loader.ts
@@ -14,8 +14,10 @@
 
 import * as fs from 'fs';
 import * as pathlib from 'path';
-import {parse as parseUrl, Url} from 'url';
+import {Url, parse as parseUrl} from 'url';
+
 import {UrlLoader} from './url-loader';
+
 
 /**
  * Resolves requests via the file system.

--- a/src/url-loader/fs-url-loader.ts
+++ b/src/url-loader/fs-url-loader.ts
@@ -1,11 +1,15 @@
 /**
  * @license
  * Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
- * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
- * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
- * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
  * Code distributed by Google as part of the polymer project is also
- * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
  */
 
 import * as fs from 'fs';
@@ -19,9 +23,7 @@ import {UrlLoader} from './url-loader';
 export class FSUrlLoader implements UrlLoader {
   root: string;
 
-  constructor(root: string) {
-    this.root = root;
-  }
+  constructor(root: string) { this.root = root; }
 
   canLoad(url: string): boolean {
     let urlObject = parseUrl(url);
@@ -30,8 +32,8 @@ export class FSUrlLoader implements UrlLoader {
   }
 
   _isValid(urlObject: Url, pathname: string) {
-    return (urlObject.protocol === 'file' || !urlObject.hostname)
-        && !pathname.startsWith('../');
+    return (urlObject.protocol === 'file' || !urlObject.hostname) &&
+        !pathname.startsWith('../');
   }
 
   load(url: string): Promise<string> {

--- a/src/url-loader/fs-url-loader.ts
+++ b/src/url-loader/fs-url-loader.ts
@@ -23,7 +23,9 @@ import {UrlLoader} from './url-loader';
 export class FSUrlLoader implements UrlLoader {
   root: string;
 
-  constructor(root: string) { this.root = root; }
+  constructor(root: string) {
+    this.root = root;
+  }
 
   canLoad(url: string): boolean {
     let urlObject = parseUrl(url);

--- a/src/url-loader/package-url-resolver.ts
+++ b/src/url-loader/package-url-resolver.ts
@@ -1,11 +1,15 @@
 /**
  * @license
  * Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
- * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
- * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
- * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
  * Code distributed by Google as part of the polymer project is also
- * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
  */
 
 import {posix as pathlib} from 'path';
@@ -21,7 +25,6 @@ export interface PackageUrlResolverOptions {
  * Resolves a URL to a canonical URL within a package.
  */
 export class PackageUrlResolver implements UrlResolver {
-
   componentDir: string;
   hostname: string;
 
@@ -38,8 +41,8 @@ export class PackageUrlResolver implements UrlResolver {
   }
 
   _isValid(urlObject: Url, pathname: string) {
-    return (urlObject.hostname === this.hostname || !urlObject.hostname)
-        && !pathname.startsWith('../../');
+    return (urlObject.hostname === this.hostname || !urlObject.hostname) &&
+        !pathname.startsWith('../../');
   }
 
   resolve(url: string): string {

--- a/src/url-loader/package-url-resolver.ts
+++ b/src/url-loader/package-url-resolver.ts
@@ -13,7 +13,8 @@
  */
 
 import {posix as pathlib} from 'path';
-import {parse as parseUrl, Url} from 'url';
+import {Url, parse as parseUrl} from 'url';
+
 import {UrlResolver} from './url-resolver';
 
 export interface PackageUrlResolverOptions {

--- a/src/url-loader/url-loader.ts
+++ b/src/url-loader/url-loader.ts
@@ -3,7 +3,6 @@
  * An object that reads files.
  */
 export interface UrlLoader {
-
   /**
    * Returns `true` if this loader can load the given `url`.
    */
@@ -15,5 +14,4 @@ export interface UrlLoader {
    * This should only be called if `canLoad` returns `true` for `url`.
    */
   load(url: string): Promise<string>;
-
 }

--- a/src/url-loader/url-resolver.ts
+++ b/src/url-loader/url-resolver.ts
@@ -7,7 +7,6 @@
  * to '/bower_components/polymer/polymer.html'.
  */
 export interface UrlResolver {
-
   /**
    * Returns `true` if this resolver can resolve the given `url`.
    */

--- a/test/analyzer_test.js
+++ b/test/analyzer_test.js
@@ -1,11 +1,15 @@
 /**
  * @license
  * Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
- * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
- * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
- * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
  * Code distributed by Google as part of the polymer project is also
- * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
  */
 
 "use strict";
@@ -20,8 +24,10 @@ const DocumentDescriptor = require('../lib/ast/ast').DocumentDescriptor;
 const FSUrlLoader = require('../lib/url-loader/fs-url-loader').FSUrlLoader;
 const Document = require('../lib/parser/document').Document;
 const HtmlDocument = require('../lib/html/html-document').HtmlDocument;
-const JavaScriptDocument = require('../lib/javascript/javascript-document').JavaScriptDocument;
-const ImportDescriptor = require('../lib/ast/import-descriptor').ImportDescriptor;
+const JavaScriptDocument =
+    require('../lib/javascript/javascript-document').JavaScriptDocument;
+const ImportDescriptor =
+    require('../lib/ast/import-descriptor').ImportDescriptor;
 
 suite('Analyzer', () => {
   let analyzer;
@@ -35,19 +41,17 @@ suite('Analyzer', () => {
   suite('load()', () => {
 
     test('loads and parses an HTML document', () => {
-      return analyzer.load('/static/html-parse-target.html')
-        .then((doc) => {
-          assert.instanceOf(doc, HtmlDocument);
-          assert.equal(doc.url, '/static/html-parse-target.html');
-        });
+      return analyzer.load('/static/html-parse-target.html').then((doc) => {
+        assert.instanceOf(doc, HtmlDocument);
+        assert.equal(doc.url, '/static/html-parse-target.html');
+      });
     });
 
     test('loads and parses a JavaScript document', () => {
-      return analyzer.load('/static/js-elements.js')
-        .then((doc) => {
-          assert.instanceOf(doc, JavaScriptDocument);
-          assert.equal(doc.url, '/static/js-elements.js');
-        });
+      return analyzer.load('/static/js-elements.js').then((doc) => {
+        assert.instanceOf(doc, JavaScriptDocument);
+        assert.equal(doc.url, '/static/js-elements.js');
+      });
     });
 
     test('returns a Promise that rejects for non-existant files', () => {
@@ -64,17 +68,17 @@ suite('Analyzer', () => {
 
     test('returns a Promise that resolves to a DocumentDescriptor', () => {
       return analyzer.analyze('/static/html-parse-target.html')
-        .then((descriptor) => {
-          // TODO(justinfagnani): add a lot more checks, especially for
-          // transitive dependencies
-        });
+          .then(
+              (descriptor) => {
+                  // TODO(justinfagnani): add a lot more checks, especially for
+                  // transitive dependencies
+              });
     });
 
     test('returns a Promise that rejects for malformed files', () => {
       return invertPromise(analyzer.analyze('static/malformed.html'))
-        .then((error) => {
-          assert.include(error.message, 'malformed.html');
-        });
+          .then(
+              (error) => { assert.include(error.message, 'malformed.html'); });
     });
 
   });
@@ -91,7 +95,7 @@ suite('Analyzer', () => {
         url: 'test.html',
         contents,
         ast,
-      })
+      });
       return analyzer.getEntities(document).then((entities) => {
         assert.equal(entities.length, 3);
         assert.equal(entities[0].type, 'html-import');
@@ -113,7 +117,7 @@ suite('Analyzer', () => {
         url: 'test.html',
         contents,
         ast,
-      })
+      });
       return analyzer.getEntities(document).then((entities) => {
         assert.equal(entities.length, 2);
         assert.instanceOf(entities[0], DocumentDescriptor);

--- a/test/analyzer_test.js
+++ b/test/analyzer_test.js
@@ -77,8 +77,9 @@ suite('Analyzer', () => {
 
     test('returns a Promise that rejects for malformed files', () => {
       return invertPromise(analyzer.analyze('static/malformed.html'))
-          .then(
-              (error) => { assert.include(error.message, 'malformed.html'); });
+          .then((error) => {
+            assert.include(error.message, 'malformed.html');
+          });
     });
 
   });

--- a/test/ast-utils/jsdoc_test.js
+++ b/test/ast-utils/jsdoc_test.js
@@ -1,11 +1,15 @@
 /**
  * @license
  * Copyright (c) 2014 The Polymer Project Authors. All rights reserved.
- * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
- * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
- * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
  * Code distributed by Google as part of the polymer project is also
- * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
  */
 
 "use strict";

--- a/test/css/css-parser_test.js
+++ b/test/css/css-parser_test.js
@@ -1,11 +1,15 @@
 /**
  * @license
  * Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
- * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
- * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
- * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
  * Code distributed by Google as part of the polymer project is also
- * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
  */
 
 "use strict";
@@ -24,12 +28,8 @@ suite('CssParser', () => {
 
     setup(() => {
       parser = new CssParser({
-        findImports(url, document) {
-          return [];
-        },
-        parse(type, content, url) {
-          return null;
-        },
+        findImports(url, document) { return []; },
+        parse(type, content, url) { return null; },
       });
     });
 
@@ -42,8 +42,7 @@ suite('CssParser', () => {
       assert(document.ast != null);
     });
 
-    test.skip('throws syntax errors', () => {
-    });
+    test.skip('throws syntax errors', () => {});
 
   });
 

--- a/test/css/css-parser_test.js
+++ b/test/css/css-parser_test.js
@@ -28,8 +28,12 @@ suite('CssParser', () => {
 
     setup(() => {
       parser = new CssParser({
-        findImports(url, document) { return []; },
-        parse(type, content, url) { return null; },
+        findImports(url, document) {
+          return [];
+        },
+        parse(type, content, url) {
+          return null;
+        },
       });
     });
 

--- a/test/entity/find-entities_test.js
+++ b/test/entity/find-entities_test.js
@@ -1,11 +1,15 @@
 /**
  * @license
  * Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
- * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
- * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
- * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
  * Code distributed by Google as part of the polymer project is also
- * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
  */
 
 "use strict";
@@ -26,17 +30,14 @@ suite('findEntities()', () => {
     let finder = new EntityFinderStub([entity]);
     let document = {
       type: 'html',
-      visit(visitors) {
-        return Promise.resolve();
-      },
+      visit(visitors) { return Promise.resolve(); },
     };
-    return findEntities(document, [finder])
-      .then((entities) => {
-        assert.equal(finder.calls.length, 1);
-        assert.equal(finder.calls[0].document, document);
-        assert.equal(entities.length, 1);
-        assert.equal(entities[0], entity);
-      });
+    return findEntities(document, [finder]).then((entities) => {
+      assert.equal(finder.calls.length, 1);
+      assert.equal(finder.calls[0].document, document);
+      assert.equal(entities.length, 1);
+      assert.equal(entities[0], entity);
+    });
   });
 
   test('supports multiple and async calls to visit()', () => {
@@ -47,18 +48,14 @@ suite('findEntities()', () => {
       findEntities(document, visit) {
         // two visitors in one batch
         return Promise.all([visit(visitor1), visit(visitor2)])
-          .then(() => {
-            // one visitor in a subsequent batch, delayed a turn to make sure
-            // we can call visit() truly async
-            return new Promise((resolve, reject) => {
-              setTimeout(() => {
-                visit(visitor3).then(resolve);
-              }, 0);
-            });
-          })
-          .then(() => {
-            return [`an entity`];
-          });
+            .then(() => {
+              // one visitor in a subsequent batch, delayed a turn to make sure
+              // we can call visit() truly async
+              return new Promise((resolve, reject) => {
+                setTimeout(() => { visit(visitor3).then(resolve); }, 0);
+              });
+            })
+            .then(() => { return [`an entity`]; });
       },
     };
     let visitedVisitors = [];
@@ -69,41 +66,32 @@ suite('findEntities()', () => {
       },
     };
 
-    return findEntities(document, [finder])
-      .then((entities) => {
-        assert.equal(visitedVisitors.length, 3);
-        assert.equal(visitedVisitors[0], visitor1);
-        assert.equal(visitedVisitors[1], visitor2);
-        assert.equal(visitedVisitors[2], visitor3);
-      });
+    return findEntities(document, [finder]).then((entities) => {
+      assert.equal(visitedVisitors.length, 3);
+      assert.equal(visitedVisitors[0], visitor1);
+      assert.equal(visitedVisitors[1], visitor2);
+      assert.equal(visitedVisitors[2], visitor3);
+    });
   });
 
   test('propagates exceptions in entity finders', () => {
     let finder = {
-      findEntities(document, visit) {
-        throw new Error('expected');
-      },
+      findEntities(document, visit) { throw new Error('expected'); },
     };
     let document = {
       type: 'html',
-      visit(visitors) {
-        return Promise.resolve();
-      },
+      visit(visitors) { return Promise.resolve(); },
     };
     return invertPromise(findEntities(document, [finder]));
   });
 
   test('propagates exceptions in visitors', () => {
     let finder = {
-      findEntities(document, visit) {
-        return visit((x) => x);
-      },
+      findEntities(document, visit) { return visit((x) => x); },
     };
     let document = {
       type: 'html',
-      visit(visitors) {
-        throw new Error('expected');
-      },
+      visit(visitors) { throw new Error('expected'); },
     };
     return invertPromise(findEntities(document, [finder]));
   });
@@ -112,7 +100,6 @@ suite('findEntities()', () => {
 
 
 class EntityFinderStub {
-
   constructor(entities) {
     this.entities = entities;
     this.calls = [];
@@ -122,5 +109,4 @@ class EntityFinderStub {
     this.calls.push({document, visit});
     return Promise.resolve(this.entities);
   }
-
 }

--- a/test/entity/find-entities_test.js
+++ b/test/entity/find-entities_test.js
@@ -30,7 +30,9 @@ suite('findEntities()', () => {
     let finder = new EntityFinderStub([entity]);
     let document = {
       type: 'html',
-      visit(visitors) { return Promise.resolve(); },
+      visit(visitors) {
+        return Promise.resolve();
+      },
     };
     return findEntities(document, [finder]).then((entities) => {
       assert.equal(finder.calls.length, 1);
@@ -52,10 +54,14 @@ suite('findEntities()', () => {
               // one visitor in a subsequent batch, delayed a turn to make sure
               // we can call visit() truly async
               return new Promise((resolve, reject) => {
-                setTimeout(() => { visit(visitor3).then(resolve); }, 0);
+                setTimeout(() => {
+                  visit(visitor3).then(resolve);
+                }, 0);
               });
             })
-            .then(() => { return [`an entity`]; });
+            .then(() => {
+              return [`an entity`];
+            });
       },
     };
     let visitedVisitors = [];
@@ -76,22 +82,30 @@ suite('findEntities()', () => {
 
   test('propagates exceptions in entity finders', () => {
     let finder = {
-      findEntities(document, visit) { throw new Error('expected'); },
+      findEntities(document, visit) {
+        throw new Error('expected');
+      },
     };
     let document = {
       type: 'html',
-      visit(visitors) { return Promise.resolve(); },
+      visit(visitors) {
+        return Promise.resolve();
+      },
     };
     return invertPromise(findEntities(document, [finder]));
   });
 
   test('propagates exceptions in visitors', () => {
     let finder = {
-      findEntities(document, visit) { return visit((x) => x); },
+      findEntities(document, visit) {
+        return visit((x) => x);
+      },
     };
     let document = {
       type: 'html',
-      visit(visitors) { throw new Error('expected'); },
+      visit(visitors) {
+        throw new Error('expected');
+      },
     };
     return invertPromise(findEntities(document, [finder]));
   });

--- a/test/html/html-import-finder_test.js
+++ b/test/html/html-import-finder_test.js
@@ -28,7 +28,9 @@ suite('HtmlImportFinder', () => {
   suite('findImports()', () => {
     let finder;
 
-    setup(() => { finder = new HtmlImportFinder(); });
+    setup(() => {
+      finder = new HtmlImportFinder();
+    });
 
     test('finds HTML Imports', () => {
       let contents = `<html><head>

--- a/test/html/html-import-finder_test.js
+++ b/test/html/html-import-finder_test.js
@@ -1,11 +1,15 @@
 /**
  * @license
  * Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
- * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
- * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
- * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
  * Code distributed by Google as part of the polymer project is also
- * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
  */
 
 "use strict";
@@ -16,16 +20,15 @@ const parse5 = require('parse5');
 const path = require('path');
 
 const HtmlDocument = require('../../lib/html/html-document').HtmlDocument;
-const HtmlImportFinder = require('../../lib/html/html-import-finder').HtmlImportFinder;
+const HtmlImportFinder =
+    require('../../lib/html/html-import-finder').HtmlImportFinder;
 
 suite('HtmlImportFinder', () => {
 
   suite('findImports()', () => {
     let finder;
 
-    setup(() => {
-      finder = new HtmlImportFinder();
-    });
+    setup(() => { finder = new HtmlImportFinder(); });
 
     test('finds HTML Imports', () => {
       let contents = `<html><head>
@@ -42,12 +45,11 @@ suite('HtmlImportFinder', () => {
       });
       let visit = (visitor) => document.visit([visitor]);
 
-      return finder.findEntities(document, visit)
-        .then((entities) => {
-          assert.equal(entities.length, 1);
-          assert.equal(entities[0].type, 'html-import');
-          assert.equal(entities[0].url, 'polymer.html');
-        });
+      return finder.findEntities(document, visit).then((entities) => {
+        assert.equal(entities.length, 1);
+        assert.equal(entities[0].type, 'html-import');
+        assert.equal(entities[0].url, 'polymer.html');
+      });
 
     });
 

--- a/test/html/html-parser_test.js
+++ b/test/html/html-parser_test.js
@@ -29,8 +29,12 @@ suite('HtmlParser', () => {
 
     setup(() => {
       parser = new HtmlParser({
-        findImports(url, document) { return [{type: 'html', url: 'abc'}]; },
-        parse(type, content, url) { return null; },
+        findImports(url, document) {
+          return [{type: 'html', url: 'abc'}];
+        },
+        parse(type, content, url) {
+          return null;
+        },
       });
     });
 

--- a/test/html/html-parser_test.js
+++ b/test/html/html-parser_test.js
@@ -1,11 +1,15 @@
 /**
  * @license
  * Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
- * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
- * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
- * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
  * Code distributed by Google as part of the polymer project is also
- * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
  */
 
 "use strict";
@@ -25,12 +29,8 @@ suite('HtmlParser', () => {
 
     setup(() => {
       parser = new HtmlParser({
-        findImports(url, document) {
-          return [{type: 'html', url: 'abc'}];
-        },
-        parse(type, content, url) {
-          return null;
-        },
+        findImports(url, document) { return [{type: 'html', url: 'abc'}]; },
+        parse(type, content, url) { return null; },
       });
     });
 
@@ -43,7 +43,8 @@ suite('HtmlParser', () => {
 
     // enable when parse() or another method parses inline scripts
     test.skip('throws when parsing a malformed document', () => {
-      let file = fs.readFileSync(path.resolve(__dirname, '../static/malformed.html'), 'utf8');
+      let file = fs.readFileSync(
+          path.resolve(__dirname, '../static/malformed.html'), 'utf8');
       assert.throws(() => {
         let document = parser.parse(file, '/static/malformed.html');
         console.log('document', document);

--- a/test/html/html-script-finder_test.js
+++ b/test/html/html-script-finder_test.js
@@ -1,11 +1,15 @@
 /**
  * @license
  * Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
- * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
- * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
- * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
  * Code distributed by Google as part of the polymer project is also
- * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
  */
 
 "use strict";
@@ -15,8 +19,10 @@ const parse5 = require('parse5');
 
 const Analyzer = require('../../lib/analyzer').Analyzer;
 const HtmlDocument = require('../../lib/html/html-document').HtmlDocument;
-const HtmlScriptFinder = require('../../lib/html/html-script-finder').HtmlScriptFinder;
-const ImportDescriptor = require('../../lib/ast/import-descriptor').ImportDescriptor;
+const HtmlScriptFinder =
+    require('../../lib/html/html-script-finder').HtmlScriptFinder;
+const ImportDescriptor =
+    require('../../lib/ast/import-descriptor').ImportDescriptor;
 const DocumentDescriptor = require('../../lib/ast/ast').DocumentDescriptor;
 
 suite('HtmlScriptFinder', () => {
@@ -43,15 +49,14 @@ suite('HtmlScriptFinder', () => {
       let promises = [];
       let visit = (visitor) => document.visit([visitor]);
 
-      return finder.findEntities(document, visit)
-        .then((entities) => {
-          assert.equal(entities.length, 2);
-          assert.instanceOf(entities[0], ImportDescriptor);
-          assert.equal(entities[0].type, 'html-script');
-          assert.equal(entities[0].url, 'foo.js');
-          assert.instanceOf(entities[1], DocumentDescriptor);
-          assert.equal(entities[1].document.url, 'test.html');
-        });
+      return finder.findEntities(document, visit).then((entities) => {
+        assert.equal(entities.length, 2);
+        assert.instanceOf(entities[0], ImportDescriptor);
+        assert.equal(entities[0].type, 'html-script');
+        assert.equal(entities[0].url, 'foo.js');
+        assert.instanceOf(entities[1], DocumentDescriptor);
+        assert.equal(entities[1].document.url, 'test.html');
+      });
 
     });
 

--- a/test/javascript/javascript-parser_test.js
+++ b/test/javascript/javascript-parser_test.js
@@ -1,11 +1,15 @@
 /**
  * @license
  * Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
- * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
- * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
- * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
  * Code distributed by Google as part of the polymer project is also
- * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
  */
 
 "use strict";
@@ -14,8 +18,10 @@ const assert = require('chai').assert;
 const fs = require('fs');
 const path = require('path');
 
-const JavaScriptParser = require('../../lib/javascript/javascript-parser').JavaScriptParser;
-const JavaScriptDocument = require('../../lib/javascript/javascript-document').JavaScriptDocument;
+const JavaScriptParser =
+    require('../../lib/javascript/javascript-parser').JavaScriptParser;
+const JavaScriptDocument =
+    require('../../lib/javascript/javascript-document').JavaScriptDocument;
 
 suite('JavaScriptParser', () => {
 
@@ -24,12 +30,8 @@ suite('JavaScriptParser', () => {
 
     setup(() => {
       parser = new JavaScriptParser({
-        findImports(url, document) {
-          return [];
-        },
-        parse(type, content, url) {
-          return null;
-        },
+        findImports(url, document) { return []; },
+        parse(type, content, url) { return null; },
       });
     });
 

--- a/test/javascript/javascript-parser_test.js
+++ b/test/javascript/javascript-parser_test.js
@@ -30,8 +30,12 @@ suite('JavaScriptParser', () => {
 
     setup(() => {
       parser = new JavaScriptParser({
-        findImports(url, document) { return []; },
-        parse(type, content, url) { return null; },
+        findImports(url, document) {
+          return [];
+        },
+        parse(type, content, url) {
+          return null;
+        },
       });
     });
 

--- a/test/static/es6-support-simple.js
+++ b/test/static/es6-support-simple.js
@@ -1,6 +1,8 @@
 'use strict';
 class A {
-  constructor() { super(); }
+  constructor() {
+    super();
+  }
 
   beforeRegister() {
     this.is = 'test-seed';
@@ -41,7 +43,9 @@ class A {
    * Test comment.
    * @param {string=} string Optional string
    */
-  test(string) { this.data = 'Hello World'; }
+  test(string) {
+    this.data = 'Hello World';
+  }
 }
 
 Polymer(A);

--- a/test/static/es6-support-simple.js
+++ b/test/static/es6-support-simple.js
@@ -1,8 +1,6 @@
 'use strict';
 class A {
-  constructor() {
-    super();
-  }
+  constructor() { super(); }
 
   beforeRegister() {
     this.is = 'test-seed';
@@ -26,7 +24,7 @@ class A {
       },
     }
 
-    this.observers = [
+                      this.observers = [
       '_observer1(string)',
       '_observer2(string)',
     ]
@@ -43,9 +41,7 @@ class A {
    * Test comment.
    * @param {string=} string Optional string
    */
-  test(string) {
-    this.data = 'Hello World';
-  }
+  test(string) { this.data = 'Hello World'; }
 }
 
 Polymer(A);

--- a/test/static/es6-support.js
+++ b/test/static/es6-support.js
@@ -1,8 +1,6 @@
 'use strict';
 class A {
-  constructor() {
-    super();
-  }
+  constructor() { super(); }
 
   beforeRegister() {
     this.is = 'test-seed';
@@ -26,7 +24,7 @@ class A {
       },
     }
 
-    this.observers = [
+                      this.observers = [
       '_observer1(string)',
       '_observer2(string)',
     ]
@@ -43,9 +41,7 @@ class A {
    * Test comment.
    * @param {string=} string Optional string
    */
-  test(string) {
-    this.data = 'Hello World';
-  }
+  test(string) { this.data = 'Hello World'; }
 }
 
 Polymer(A);
@@ -97,27 +93,18 @@ Polymer({
     /**
      * I am an object with notify=true!
      */
-    objectNotify: {
-      type: Object,
-      notify: true
-    },
+    objectNotify: {type: Object, notify: true},
     /**
      * I am an object with notify=!0
      */
-    objectNotifyUnary: {
-      type: Object,
-      notify: !0
-    },
+    objectNotifyUnary: {type: Object, notify: !0},
     /**
      * I am a boolean property!
      */
     boolProp: Boolean
   },
 
-  bind: {
-    numProp: 'numChanged',
-    elementProp: 'elemChanged'
-  },
+  bind: {numProp: 'numChanged', elementProp: 'elemChanged'},
 
   numChanged: function() {
 

--- a/test/static/es6-support.js
+++ b/test/static/es6-support.js
@@ -1,6 +1,8 @@
 'use strict';
 class A {
-  constructor() { super(); }
+  constructor() {
+    super();
+  }
 
   beforeRegister() {
     this.is = 'test-seed';
@@ -41,7 +43,9 @@ class A {
    * Test comment.
    * @param {string=} string Optional string
    */
-  test(string) { this.data = 'Hello World'; }
+  test(string) {
+    this.data = 'Hello World';
+  }
 }
 
 Polymer(A);

--- a/test/static/js-behaviors.js
+++ b/test/static/js-behaviors.js
@@ -4,28 +4,21 @@ var SimpleBehavior = {
 };
 
 /** @polymerBehavior AwesomeBehavior */
-var CustomNamedBehavior = {
-  custom: true,
-  properties: {
-    a: {
-      value: 1
-    }
-  }
-};
+var CustomNamedBehavior = {custom: true, properties: {a: {value: 1}}};
 
 /**
 With a chained behavior
 @polymerBehavior
 */
-Really.Really.Deep.Behavior = [{
-  deep: true,
-}, Do.Re.Mi.Fa];
+Really.Really.Deep.Behavior = [
+  {
+    deep: true,
+  },
+  Do.Re.Mi.Fa
+];
 
 /**
 @polymerBehavior
 */
-CustomBehaviorList = [
-  SimpleBehavior,
-  CustomNamedBehavior,
-  Really.Really.Deep.Behavior
-];
+CustomBehaviorList =
+    [SimpleBehavior, CustomNamedBehavior, Really.Really.Deep.Behavior];

--- a/test/static/js-elements.js
+++ b/test/static/js-elements.js
@@ -437,7 +437,9 @@ Polymer({
     }
   },
 
-  remove: function(key) { this.ref.child(key).remove(this.errorHandler); },
+  remove: function(key) {
+    this.ref.child(key).remove(this.errorHandler);
+  },
 
   commit: function() {
     this.log && console.log('commit');

--- a/test/static/js-elements.js
+++ b/test/static/js-elements.js
@@ -49,27 +49,18 @@ Polymer({
     /**
      * I am an object with notify=true!
      */
-    objectNotify: {
-      type: Object,
-      notify: true
-    },
+    objectNotify: {type: Object, notify: true},
     /**
      * I am an object with notify=!0
      */
-    objectNotifyUnary: {
-      type: Object,
-      notify: !0
-    },
+    objectNotifyUnary: {type: Object, notify: !0},
     /**
      * I am a boolean property!
      */
     boolProp: Boolean
   },
 
-  bind: {
-    numProp: 'numChanged',
-    elementProp: 'elemChanged'
-  },
+  bind: {numProp: 'numChanged', elementProp: 'elemChanged'},
 
   numChanged: function() {
 
@@ -133,21 +124,17 @@ Polymer({
      * @attribute data
      * @type Object
      */
-    data: {
-      type: Object,
-      notify: true
-    },
+    data: {type: Object, notify: true},
     /**
-     * All keys in data (array of names, if you think of data as a set of name/value pairs).
+     * All keys in data (array of names, if you think of data as a set of
+     * name/value pairs).
      * @attribute keys
      * @type Array
      */
-    keys: {
-      type: Array,
-      notify: true
-    },
+    keys: {type: Array, notify: true},
     /**
-     * If true, will fire `child-added`, `child-removed`, `child-changed` events.
+     * If true, will fire `child-added`, `child-removed`, `child-changed`
+     * events.
      * @attribute childEvents
      * @type Boolean
      */
@@ -163,10 +150,7 @@ Polymer({
      * @attribute initialized
      * @type Boolean
      */
-    dataReady: {
-      type: Boolean,
-      notify: true
-    },
+    dataReady: {type: Boolean, notify: true},
     /**
      * If true, will log various occurances to the console api.
      * @attribute log
@@ -243,7 +227,8 @@ Polymer({
   valueLoaded: function(snapshot) {
     this.valueLoading = false;
     if (this.ref.key() !== snapshot.key()) {
-      this.log && console.warn('squelching stale response [%s]', snapshot.key());
+      this.log &&
+          console.warn('squelching stale response [%s]', snapshot.key());
       return;
     }
     this.log && console.log('acquired value ' + this.location);
@@ -277,8 +262,10 @@ Polymer({
     // server side dynamics
     if (this.data instanceof Object || this.data instanceof Array) {
       this.query.on('child_added', this.childAdded, this.errorHandler, this);
-      this.query.on('child_changed', this.childChanged, this.errorHandler, this);
-      this.query.on('child_removed', this.childRemoved, this.errorHandler, this);
+      this.query.on(
+          'child_changed', this.childChanged, this.errorHandler, this);
+      this.query.on(
+          'child_removed', this.childRemoved, this.errorHandler, this);
     } else {
       this.query.on('value', this.valueUpdated, this.errorHandler, this);
     }
@@ -344,7 +331,8 @@ Polymer({
       // ignore initial adds, we'll take the 'value' instead
       this.modulateData('updateData', snapshot);
     } else if (!this.valueLoading) {
-      // if children are added to a previously null location, grab the whole value in one go
+      // if children are added to a previously null location, grab the whole
+      // value in one go
       this.valueLoading = true;
       this.query.once('value', this.valueLoaded, this);
     }
@@ -405,14 +393,15 @@ Polymer({
   },
 
   dataChange: function() {
-    //this.job('change', function() {
-      if (this.data) {
-        this.keys = this.data instanceof Object ? Object.keys(this.data) : [];
-      }
-      // TODO(kschaaf): Notify when bind-effects-object experimental feature is enabled
-      if (this.notifyPropertyChange) {
-        this.notifyPropertyChange('data');
-      }
+    // this.job('change', function() {
+    if (this.data) {
+      this.keys = this.data instanceof Object ? Object.keys(this.data) : [];
+    }
+    // TODO(kschaaf): Notify when bind-effects-object experimental feature is
+    // enabled
+    if (this.notifyPropertyChange) {
+      this.notifyPropertyChange('data');
+    }
     //});
   },
 
@@ -420,7 +409,7 @@ Polymer({
   // client-side effects
   //
   observeArray: function(splices) {
-    //console.warn('observeArray');
+    // console.warn('observeArray');
     // TODO(sjmiles): arrays are nasty because simple insertions/deletions
     // cause changes to ripple through keys
     this.commit();
@@ -448,15 +437,14 @@ Polymer({
     }
   },
 
-  remove: function(key) {
-    this.ref.child(key).remove(this.errorHandler);
-  },
+  remove: function(key) { this.ref.child(key).remove(this.errorHandler); },
 
   commit: function() {
     this.log && console.log('commit');
     if (this.ref) {
       if (this.priority != null) {
-        this.ref.setWithPriority(this.data || {}, this.priority, this.errorHandler);
+        this.ref.setWithPriority(
+            this.data || {}, this.priority, this.errorHandler);
       } else {
         this.ref.set(this.data || {}, this.errorHandler);
       }
@@ -466,7 +454,7 @@ Polymer({
   push: function(item) {
     var neo;
     if (this.data instanceof Array) {
-      this.commitProperty(this.data.push(item)-1);
+      this.commitProperty(this.data.push(item) - 1);
     } else {
       neo = this.ref.push(item, this.errorHandler);
     }

--- a/test/static/js-parse-error.js
+++ b/test/static/js-parse-error.js
@@ -1,35 +1,38 @@
 modulate('bare-module', function() {
-    return {
-
-      /**
-       * User must call from `attached` callback
-       *
-       * @method resizableAttached
-       */
+  return {
+    /**
+     * User must call from `attached` callback
+     *
+     * @method resizableAttached
+     */
       resizableAttached: function(cb) {
-        cb = cb || this._notifyResizeSelf;
+      cb = cb || this._notifyResizeSelf;
         this.async(function() {
-          var detail = {callback: cb, hasParentResizer: false};
-          this.fire('x-request-resize', detail);
-          if (!detail.hasParentResizer) {
-            this._boundWindowResizeHandler = cb.bind(this);
+        var detail = {callback: cb, hasParentResizer: false};
+        this.fire('x-request-resize', detail);
+        if (!detail.hasParentResizer) {
+          this._boundWindowResizeHandler = cb.bind(this);
 
-              window.addEventLis},[]tener('resize', this._boundWindowResizeHandler);
+          window.addEventLis
+        }
+        , [] tener('resize', this._boundWindowResizeHandler);
           }
         }.bind(this));
-      },
+  }
+  ,
 
       /**
        * User must call from `detached` callback
        *
        * @method resizableDetached
        */
-      resizableDetached: function() {
-        this.fire('x-request-resize-cancel', null, this, false);
-        if (this._boundWindowResizeHandler) {
-          window.removeEventListener(this._boundResizeHandler);
-        }
-      },
+      resizableDetached:
+          function() {
+            this.fire('x-request-resize-cancel', null, this, false);
+            if (this._boundWindowResizeHandler) {
+              window.removeEventListener(this._boundResizeHandler);
+            }
+          },
 
       // Private: fire non-bubbling resize event to self; returns whether
       // preventDefault was called, indicating that children should not
@@ -39,4 +42,4 @@ modulate('bare-module', function() {
       }
 
     };
-  });
+});

--- a/test/test-utils.js
+++ b/test/test-utils.js
@@ -1,27 +1,29 @@
 /**
  * @license
  * Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
- * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
- * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
- * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
  * Code distributed by Google as part of the polymer project is also
- * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
  */
 
 "use strict";
 
 function invertPromise(promise) {
   return new Promise((resolve, reject) => {
-    promise.then(
-      (value) => {
-        let error = new Error('Inverted Promise resolved');
-        error.resolvedValue = value;
-        reject(error);
-      },
-      resolve);
+    promise.then((value) => {
+      let error = new Error('Inverted Promise resolved');
+      error.resolvedValue = value;
+      reject(error);
+    }, resolve);
   });
 }
 
 module.exports = {
-  invertPromise,
+    invertPromise,
 };

--- a/test/url-loader/fs-url-loader_test.js
+++ b/test/url-loader/fs-url-loader_test.js
@@ -1,11 +1,15 @@
 /**
  * @license
  * Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
- * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
- * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
- * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
  * Code distributed by Google as part of the polymer project is also
- * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
  */
 
 'use strict';
@@ -43,7 +47,8 @@ suite('FSUrlLoader', function() {
     });
 
     test('resolves an in-package URL', () => {
-      assert.equal(new FSUrlLoader('root').getFilePath('foo.html'), 'root/foo.html');
+      assert.equal(
+          new FSUrlLoader('root').getFilePath('foo.html'), 'root/foo.html');
     });
 
     test('throws for a sibling URL', () => {
@@ -55,7 +60,8 @@ suite('FSUrlLoader', function() {
     });
 
     test('throws for a URL with a hostname', () => {
-      assert.throws(() => new FSUrlLoader().getFilePath('http://abc.xyz/foo.html'));
+      assert.throws(
+          () => new FSUrlLoader().getFilePath('http://abc.xyz/foo.html'));
     });
 
   });

--- a/test/url-loader/package-url-resolver_test.js
+++ b/test/url-loader/package-url-resolver_test.js
@@ -1,19 +1,23 @@
 /**
  * @license
  * Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
- * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
- * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
- * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
  * Code distributed by Google as part of the polymer project is also
- * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
  */
 
 'use strict';
 
 const assert = require('chai').assert;
 
-const PackageUrlResolver = require('../../lib/url-loader/package-url-resolver')
-    .PackageUrlResolver;
+const PackageUrlResolver =
+    require('../../lib/url-loader/package-url-resolver').PackageUrlResolver;
 
 suite('PackageUrlResolver', function() {
 
@@ -35,7 +39,8 @@ suite('PackageUrlResolver', function() {
     });
 
     test('canResolve is false for URL with a hostname', () => {
-      assert.isFalse(new PackageUrlResolver().canResolve('http://abc.xyz/foo.html'));
+      assert.isFalse(
+          new PackageUrlResolver().canResolve('http://abc.xyz/foo.html'));
     });
 
     test('canResolve is true for a URL with the right hostname', () => {
@@ -66,11 +71,13 @@ suite('PackageUrlResolver', function() {
     });
 
     test('throws for a cousin URL', () => {
-      assert.throws(() => new PackageUrlResolver().resolve('../../foo/foo.html'));
+      assert.throws(
+          () => new PackageUrlResolver().resolve('../../foo/foo.html'));
     });
 
     test('throws for a URL with a hostname', () => {
-      assert.throws(() => new PackageUrlResolver().resolve('http://abc.xyz/foo.html'));
+      assert.throws(
+          () => new PackageUrlResolver().resolve('http://abc.xyz/foo.html'));
     });
 
     test('resolves a URL with the right hostname', () => {


### PR DESCRIPTION
So I tried out vscode to check whether it's typescript in general or atom in particular that's slow with the improved estree typings. Looks like it's atom in particular, as vscode doesn't lose a beat.

I also discovered that it's very easy to get it to run clang-format on save, so I decided I'd take a look to see how it would look if we adopted clang-format for the repo.